### PR TITLE
Remove credentials that were no longer necessary in the PluginManagerService

### DIFF
--- a/src/main/java/com/synopsys/integration/jira/common/rest/service/PluginManagerService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/rest/service/PluginManagerService.java
@@ -22,11 +22,8 @@
  */
 package com.synopsys.integration.jira.common.rest.service;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
-
-import org.apache.commons.codec.binary.Base64;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.exception.IntegrationException;
@@ -69,9 +66,9 @@ public class PluginManagerService {
         this.jiraApiClient = jiraApiClient;
     }
 
-    public Optional<PluginResponseModel> getInstalledApp(String username, String accessTokenOrPassword, String appKey) throws IntegrationException {
+    public Optional<PluginResponseModel> getInstalledApp(String appKey) throws IntegrationException {
         HttpUrl apiUri = new HttpUrl(createBaseRequestUrl() + appKey + "-key");
-        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri, username, accessTokenOrPassword);
+        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri);
         requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_PLUGIN);
@@ -87,9 +84,9 @@ public class PluginManagerService {
         return Optional.empty();
     }
 
-    public boolean isAppInstalled(String username, String accessTokenOrPassword, String appKey) throws IntegrationException {
+    public boolean isAppInstalled(String appKey) throws IntegrationException {
         HttpUrl apiUri = new HttpUrl(createBaseRequestUrl() + appKey + "-key");
-        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri, username, accessTokenOrPassword);
+        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri);
         requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_PLUGIN);
@@ -106,9 +103,9 @@ public class PluginManagerService {
         }
     }
 
-    public InstalledAppsResponseModel getInstalledApps(String username, String accessTokenOrPassword) throws IntegrationException {
+    public InstalledAppsResponseModel getInstalledApps() throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl(createBaseRequestUrl());
-        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(httpUrl, username, accessTokenOrPassword);
+        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(httpUrl);
         requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_INSTALLED);
@@ -116,39 +113,39 @@ public class PluginManagerService {
         return jiraApiClient.get(requestBuilder.build(), InstalledAppsResponseModel.class);
     }
 
-    public int installMarketplaceCloudApp(String addonKey, String username, String accessToken) throws IntegrationException {
+    public int installMarketplaceCloudApp(String addonKey) throws IntegrationException {
         HttpUrl apiUri = new HttpUrl(createBaseRequestUrl() + "apps/install-subscribe");
-        String pluginToken = retrievePluginToken(username, accessToken);
-        JiraRequest request = createMarketplaceInstallRequest(apiUri, username, accessToken, pluginToken, addonKey);
+        String pluginToken = retrievePluginToken();
+        JiraRequest request = createMarketplaceInstallRequest(apiUri, pluginToken, addonKey);
         return jiraApiClient.executeReturnStatus(request);
     }
 
-    public int installMarketplaceServerApp(String addonKey, String username, String password) throws IntegrationException {
+    public int installMarketplaceServerApp(String addonKey) throws IntegrationException {
         HttpUrl apiUri = new HttpUrl(createBaseRequestUrl());
-        String pluginToken = retrievePluginToken(username, password);
-        AvailableAppResponseModel availableApp = getAvailableApp(apiUri.string(), username, password, addonKey);
+        String pluginToken = retrievePluginToken();
+        AvailableAppResponseModel availableApp = getAvailableApp(apiUri.string(), addonKey);
         String pluginUri = availableApp.getBinaryLink().orElse("");
-        JiraRequest request = createAppUploadRequest(apiUri, username, password, pluginToken, availableApp.getName(), pluginUri);
+        JiraRequest request = createAppUploadRequest(apiUri, pluginToken, availableApp.getName(), pluginUri);
         return jiraApiClient.executeReturnStatus(request);
     }
 
-    public int installDevelopmentApp(String pluginName, String pluginUri, String username, String accessTokenOrPassword) throws IntegrationException {
+    public int installDevelopmentApp(String pluginName, String pluginUri) throws IntegrationException {
         HttpUrl apiUri = new HttpUrl(createBaseRequestUrl());
-        String pluginToken = retrievePluginToken(username, accessTokenOrPassword);
-        JiraRequest request = createAppUploadRequest(apiUri, username, accessTokenOrPassword, pluginToken, pluginName, pluginUri);
+        String pluginToken = retrievePluginToken();
+        JiraRequest request = createAppUploadRequest(apiUri, pluginToken, pluginName, pluginUri);
         return jiraApiClient.executeReturnStatus(request);
     }
 
-    public int uninstallApp(String appKey, String username, String accessTokenOrPassword) throws IntegrationException {
+    public int uninstallApp(String appKey) throws IntegrationException {
         HttpUrl apiUri = new HttpUrl(createBaseRequestUrl() + appKey + "-key");
-        String pluginToken = retrievePluginToken(username, accessTokenOrPassword);
-        JiraRequest request = createDeleteRequest(apiUri, username, accessTokenOrPassword, pluginToken);
+        String pluginToken = retrievePluginToken();
+        JiraRequest request = createDeleteRequest(apiUri, pluginToken);
         return jiraApiClient.executeReturnStatus(request);
     }
 
-    public String retrievePluginToken(String username, String accessTokenOrPassword) throws IntegrationException {
+    public String retrievePluginToken() throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl(createBaseRequestUrl());
-        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(httpUrl, username, accessTokenOrPassword);
+        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(httpUrl);
         requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_INSTALLED);
@@ -156,16 +153,16 @@ public class PluginManagerService {
         return response.get("upm-token");
     }
 
-    private AvailableAppResponseModel getAvailableApp(String path, String username, String password, String appKey) throws IntegrationException {
+    private AvailableAppResponseModel getAvailableApp(String path, String appKey) throws IntegrationException {
         HttpUrl apiUri = new HttpUrl(path + "available/" + appKey + "-key");
-        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri, username, password);
+        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_AVAILABLE);
         return jiraApiClient.get(requestBuilder.build(), AvailableAppResponseModel.class);
     }
 
-    private JiraRequest createMarketplaceInstallRequest(HttpUrl apiUri, String username, String accessToken, String pluginToken, String addonKey) {
-        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri, username, accessToken);
+    private JiraRequest createMarketplaceInstallRequest(HttpUrl apiUri, String pluginToken, String addonKey) {
+        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri);
         requestBuilder.addQueryParameter("addonKey", addonKey);
         requestBuilder.addQueryParameter(TOKEN_QUERY, pluginToken);
         requestBuilder.method(HttpMethod.POST);
@@ -174,8 +171,8 @@ public class PluginManagerService {
         return requestBuilder.build();
     }
 
-    private JiraRequest createAppUploadRequest(HttpUrl apiUri, String username, String accessTokenOrPassword, String pluginToken, String pluginName, String pluginUri) {
-        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri, username, accessTokenOrPassword);
+    private JiraRequest createAppUploadRequest(HttpUrl apiUri, String pluginToken, String pluginName, String pluginUri) {
+        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri);
         requestBuilder.addQueryParameter(TOKEN_QUERY, pluginToken);
         requestBuilder.method(HttpMethod.POST);
         requestBuilder.addHeader(CONTENT_TYPE_HEADER, MEDIA_TYPE_INSTALL_URI);
@@ -184,8 +181,8 @@ public class PluginManagerService {
         return requestBuilder.build();
     }
 
-    private JiraRequest createDeleteRequest(HttpUrl apiUri, String username, String accessTokenOrPassword, String pluginToken) {
-        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri, username, accessTokenOrPassword);
+    private JiraRequest createDeleteRequest(HttpUrl apiUri, String pluginToken) {
+        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri);
         requestBuilder.addQueryParameter(TOKEN_QUERY, pluginToken);
         requestBuilder.method(HttpMethod.DELETE);
         requestBuilder.addHeader(CONTENT_TYPE_HEADER, MEDIA_TYPE_DEFAULT);
@@ -193,13 +190,10 @@ public class PluginManagerService {
         return requestBuilder.build();
     }
 
-    private JiraRequest.Builder createBasicRequestBuilder(HttpUrl apiUri, String username, String accessTokenOrPassword) {
+    private JiraRequest.Builder createBasicRequestBuilder(HttpUrl apiUri) {
         JiraRequest.Builder requestBuilder = new JiraRequest.Builder();
 
         requestBuilder.url(apiUri);
-        byte[] authorizationBytes = String.format("%s:%s", username, accessTokenOrPassword).getBytes(StandardCharsets.UTF_8);
-        String authorization = String.format("Basic %s", Base64.encodeBase64String(authorizationBytes));
-        requestBuilder.addHeader("authorization", authorization);
         return requestBuilder;
     }
 

--- a/src/main/java/com/synopsys/integration/jira/common/rest/service/PluginManagerService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/rest/service/PluginManagerService.java
@@ -68,7 +68,7 @@ public class PluginManagerService {
 
     public Optional<PluginResponseModel> getInstalledApp(String appKey) throws IntegrationException {
         HttpUrl apiUri = new HttpUrl(createBaseRequestUrl() + appKey + "-key");
-        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri);
+        JiraRequest.Builder requestBuilder = new JiraRequest.Builder(apiUri);
         requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_PLUGIN);
@@ -86,7 +86,7 @@ public class PluginManagerService {
 
     public boolean isAppInstalled(String appKey) throws IntegrationException {
         HttpUrl apiUri = new HttpUrl(createBaseRequestUrl() + appKey + "-key");
-        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri);
+        JiraRequest.Builder requestBuilder = new JiraRequest.Builder(apiUri);
         requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_PLUGIN);
@@ -105,7 +105,7 @@ public class PluginManagerService {
 
     public InstalledAppsResponseModel getInstalledApps() throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl(createBaseRequestUrl());
-        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(httpUrl);
+        JiraRequest.Builder requestBuilder = new JiraRequest.Builder(httpUrl);
         requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_INSTALLED);
@@ -145,7 +145,7 @@ public class PluginManagerService {
 
     public String retrievePluginToken() throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl(createBaseRequestUrl());
-        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(httpUrl);
+        JiraRequest.Builder requestBuilder = new JiraRequest.Builder(httpUrl);
         requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_INSTALLED);
@@ -155,14 +155,14 @@ public class PluginManagerService {
 
     private AvailableAppResponseModel getAvailableApp(String path, String appKey) throws IntegrationException {
         HttpUrl apiUri = new HttpUrl(path + "available/" + appKey + "-key");
-        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri);
+        JiraRequest.Builder requestBuilder = new JiraRequest.Builder(apiUri);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_AVAILABLE);
         return jiraApiClient.get(requestBuilder.build(), AvailableAppResponseModel.class);
     }
 
     private JiraRequest createMarketplaceInstallRequest(HttpUrl apiUri, String pluginToken, String addonKey) {
-        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri);
+        JiraRequest.Builder requestBuilder = new JiraRequest.Builder(apiUri);
         requestBuilder.addQueryParameter("addonKey", addonKey);
         requestBuilder.addQueryParameter(TOKEN_QUERY, pluginToken);
         requestBuilder.method(HttpMethod.POST);
@@ -172,7 +172,7 @@ public class PluginManagerService {
     }
 
     private JiraRequest createAppUploadRequest(HttpUrl apiUri, String pluginToken, String pluginName, String pluginUri) {
-        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri);
+        JiraRequest.Builder requestBuilder = new JiraRequest.Builder(apiUri);
         requestBuilder.addQueryParameter(TOKEN_QUERY, pluginToken);
         requestBuilder.method(HttpMethod.POST);
         requestBuilder.addHeader(CONTENT_TYPE_HEADER, MEDIA_TYPE_INSTALL_URI);
@@ -182,16 +182,12 @@ public class PluginManagerService {
     }
 
     private JiraRequest createDeleteRequest(HttpUrl apiUri, String pluginToken) {
-        JiraRequest.Builder requestBuilder = createBasicRequestBuilder(apiUri);
+        JiraRequest.Builder requestBuilder = new JiraRequest.Builder(apiUri);
         requestBuilder.addQueryParameter(TOKEN_QUERY, pluginToken);
         requestBuilder.method(HttpMethod.DELETE);
         requestBuilder.addHeader(CONTENT_TYPE_HEADER, MEDIA_TYPE_DEFAULT);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_DEFAULT);
         return requestBuilder.build();
-    }
-
-    private JiraRequest.Builder createBasicRequestBuilder(HttpUrl apiUri) {
-        return new JiraRequest.Builder(apiUri);
     }
 
     private String createBodyContent(String pluginName, String pluginUri) {

--- a/src/main/java/com/synopsys/integration/jira/common/rest/service/PluginManagerService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/rest/service/PluginManagerService.java
@@ -191,10 +191,7 @@ public class PluginManagerService {
     }
 
     private JiraRequest.Builder createBasicRequestBuilder(HttpUrl apiUri) {
-        JiraRequest.Builder requestBuilder = new JiraRequest.Builder();
-
-        requestBuilder.url(apiUri);
-        return requestBuilder;
+        return new JiraRequest.Builder(apiUri);
     }
 
     private String createBodyContent(String pluginName, String pluginUri) {

--- a/src/test/java/com/synopsys/integration/jira/common/cloud/service/JiraCloudAppServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/cloud/service/JiraCloudAppServiceTest.java
@@ -22,12 +22,13 @@ import com.synopsys.integration.rest.RestConstants;
 import com.synopsys.integration.rest.exception.IntegrationRestException;
 
 public class JiraCloudAppServiceTest extends JiraCloudParameterizedTest {
+    private static final int WAIT_TIME = 1000;
     private static final String APP_KEY = "com.synopsys.integration.alert";
     private static final String APP_CLOUD_URI = "https://blackducksoftware.github.io/alert-issue-property-indexer/JiraCloudApp/1.0.0/atlassian-connect.json";
 
     @AfterEach
     public void waitForUninstallToFinish() throws InterruptedException {
-        Thread.sleep(1000);
+        Thread.sleep(JiraCloudAppServiceTest.WAIT_TIME);
     }
 
     @ParameterizedTest
@@ -37,13 +38,10 @@ public class JiraCloudAppServiceTest extends JiraCloudParameterizedTest {
         JiraCloudServiceFactory serviceFactory = JiraCloudServiceTestUtility.createServiceFactory(jiraHttpClient);
         PluginManagerService pluginManagerService = serviceFactory.createPluginManagerService();
 
-        String userEmail = JiraCloudServiceTestUtility.getEnvUserEmail();
-        String apiToken = JiraCloudServiceTestUtility.getEnvApiToken();
-
-        int installResponse = pluginManagerService.installMarketplaceCloudApp(APP_KEY, userEmail, apiToken);
+        int installResponse = pluginManagerService.installMarketplaceCloudApp(APP_KEY);
         assertTrue(isStatusCodeSuccess(installResponse), "Expected a 2xx response code, but was: " + installResponse);
-        Thread.sleep(1000);
-        int uninstallResponse = pluginManagerService.uninstallApp(APP_KEY, userEmail, apiToken);
+        Thread.sleep(JiraCloudAppServiceTest.WAIT_TIME);
+        int uninstallResponse = pluginManagerService.uninstallApp(APP_KEY);
         assertTrue(isStatusCodeSuccess(uninstallResponse), "Expected a 2xx response code, but was: " + uninstallResponse);
     }
 
@@ -56,38 +54,27 @@ public class JiraCloudAppServiceTest extends JiraCloudParameterizedTest {
         JiraCloudServiceFactory serviceFactory = JiraCloudServiceTestUtility.createServiceFactory(jiraHttpClient);
         PluginManagerService pluginManagerService = serviceFactory.createPluginManagerService();
 
-        String userEmail = JiraCloudServiceTestUtility.getEnvUserEmail();
-        String apiToken = JiraCloudServiceTestUtility.getEnvApiToken();
-
-        int installResponse = pluginManagerService.installDevelopmentApp(
-            "Test",
-            APP_CLOUD_URI,
-            userEmail,
-            apiToken
-        );
+        int installResponse = pluginManagerService.installDevelopmentApp("Test", APP_CLOUD_URI);
         assertTrue(isStatusCodeSuccess(installResponse), "Expected a 2xx response code, but was: " + installResponse);
-        Thread.sleep(1000);
-        int uninstallResponse = pluginManagerService.uninstallApp(APP_KEY, userEmail, apiToken);
+        Thread.sleep(JiraCloudAppServiceTest.WAIT_TIME);
+        int uninstallResponse = pluginManagerService.uninstallApp(APP_KEY);
         assertTrue(isStatusCodeSuccess(uninstallResponse), "Expected a 2xx response code, but was: " + uninstallResponse);
     }
 
     @ParameterizedTest
     @MethodSource("getParameters")
-    public void getInstalledAppsTest(JiraHttpClient jiraHttpClient) throws IntegrationException {
+    public void getInstalledAppsTest(JiraHttpClient jiraHttpClient) throws IntegrationException, InterruptedException {
         JiraCloudServiceTestUtility.validateConfiguration();
         JiraCloudServiceFactory serviceFactory = JiraCloudServiceTestUtility.createServiceFactory(jiraHttpClient);
         PluginManagerService pluginManagerService = serviceFactory.createPluginManagerService();
 
-        String userEmail = JiraCloudServiceTestUtility.getEnvUserEmail();
-        String apiToken = JiraCloudServiceTestUtility.getEnvApiToken();
-
-        Optional<PluginResponseModel> fakeApp = pluginManagerService.getInstalledApp(userEmail, apiToken, "not.a.real.key");
+        Optional<PluginResponseModel> fakeApp = pluginManagerService.getInstalledApp("not.a.real.key");
         assertFalse(fakeApp.isPresent(), "Expected app to not be installed");
 
-        int installResponse = pluginManagerService.installMarketplaceCloudApp(APP_KEY, userEmail, apiToken);
+        int installResponse = pluginManagerService.installMarketplaceCloudApp(APP_KEY);
         throwExceptionForError(installResponse);
 
-        InstalledAppsResponseModel installedApps = pluginManagerService.getInstalledApps(userEmail, apiToken);
+        InstalledAppsResponseModel installedApps = pluginManagerService.getInstalledApps();
         List<PluginResponseModel> allInstalledPlugins = installedApps.getPlugins();
         List<PluginResponseModel> userInstalledPlugins = allInstalledPlugins
                                                              .stream()
@@ -95,7 +82,8 @@ public class JiraCloudAppServiceTest extends JiraCloudParameterizedTest {
                                                              .collect(Collectors.toList());
         assertTrue(userInstalledPlugins.size() < allInstalledPlugins.size(), "Expected fewer user-installed plugins than total plugins");
 
-        int uninstallResponse = pluginManagerService.uninstallApp(APP_KEY, userEmail, apiToken);
+        Thread.sleep(JiraCloudAppServiceTest.WAIT_TIME);
+        int uninstallResponse = pluginManagerService.uninstallApp(APP_KEY);
         throwExceptionForError(uninstallResponse);
     }
 

--- a/src/test/java/com/synopsys/integration/jira/common/rest/service/PluginManagerServiceServerTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/rest/service/PluginManagerServiceServerTest.java
@@ -19,7 +19,7 @@ public class PluginManagerServiceServerTest extends JiraServerParameterizedTest 
         JiraServerServiceFactory serviceFactory = JiraServerServiceTestUtility.createServiceFactory(jiraHttpClient);
         PluginManagerService pluginManagerService = serviceFactory.createPluginManagerService();
 
-        boolean appInstalled = pluginManagerService.isAppInstalled(JiraServerServiceTestUtility.getEnvUsername(), JiraServerServiceTestUtility.getEnvPassword(), "com.synopsys.integration.alert");
+        boolean appInstalled = pluginManagerService.isAppInstalled("com.synopsys.integration.alert");
         System.out.println("App is installed " + appInstalled);
     }
 }

--- a/src/test/java/com/synopsys/integration/jira/common/server/JiraServerAppServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/server/JiraServerAppServiceTest.java
@@ -39,13 +39,10 @@ public class JiraServerAppServiceTest extends JiraServerParameterizedTest {
         JiraServerServiceFactory serviceFactory = JiraServerServiceTestUtility.createServiceFactory(jiraHttpClient);
         PluginManagerService pluginManagerService = serviceFactory.createPluginManagerService();
 
-        String username = JiraServerServiceTestUtility.getEnvUsername();
-        String password = JiraServerServiceTestUtility.getEnvPassword();
-
-        int installResponse = pluginManagerService.installMarketplaceServerApp(APP_FREE_MARKETPLACE_KEY, username, password);
+        int installResponse = pluginManagerService.installMarketplaceServerApp(APP_FREE_MARKETPLACE_KEY);
         assertTrue(isStatusCodeSuccess(installResponse), "Expected a 2xx response code, but was: " + installResponse);
         Thread.sleep(3000);
-        int uninstallResponse = pluginManagerService.uninstallApp(APP_FREE_MARKETPLACE_KEY, username, password);
+        int uninstallResponse = pluginManagerService.uninstallApp(APP_FREE_MARKETPLACE_KEY);
         assertTrue(isStatusCodeSuccess(uninstallResponse), "Expected a 2xx response code, but was: " + uninstallResponse);
     }
 
@@ -58,18 +55,10 @@ public class JiraServerAppServiceTest extends JiraServerParameterizedTest {
         JiraServerServiceFactory serviceFactory = JiraServerServiceTestUtility.createServiceFactory(jiraHttpClient);
         PluginManagerService pluginManagerService = serviceFactory.createPluginManagerService();
 
-        String userEmail = JiraServerServiceTestUtility.getEnvUsername();
-        String apiToken = JiraServerServiceTestUtility.getEnvPassword();
-
-        int installResponse = pluginManagerService.installDevelopmentApp(
-            "Test",
-            APP_SERVER_URI,
-            userEmail,
-            apiToken
-        );
+        int installResponse = pluginManagerService.installDevelopmentApp("Test", APP_SERVER_URI);
         assertTrue(isStatusCodeSuccess(installResponse), "Expected a 2xx response code, but was: " + installResponse);
         Thread.sleep(3000);
-        int uninstallResponse = pluginManagerService.uninstallApp(APP_KEY, userEmail, apiToken);
+        int uninstallResponse = pluginManagerService.uninstallApp(APP_KEY);
         assertTrue(isStatusCodeSuccess(uninstallResponse), "Expected a 2xx response code, but was: " + uninstallResponse);
     }
 
@@ -80,16 +69,13 @@ public class JiraServerAppServiceTest extends JiraServerParameterizedTest {
         JiraServerServiceFactory serviceFactory = JiraServerServiceTestUtility.createServiceFactory(jiraHttpClient);
         PluginManagerService pluginManagerService = serviceFactory.createPluginManagerService();
 
-        String username = JiraServerServiceTestUtility.getEnvUsername();
-        String password = JiraServerServiceTestUtility.getEnvPassword();
-
-        Optional<PluginResponseModel> fakeApp = pluginManagerService.getInstalledApp(username, password, "not.a.real.key");
+        Optional<PluginResponseModel> fakeApp = pluginManagerService.getInstalledApp("not.a.real.key");
         assertFalse(fakeApp.isPresent(), "Expected app to not be installed");
 
-        int installResponse = pluginManagerService.installMarketplaceServerApp(APP_FREE_MARKETPLACE_KEY, username, password);
+        int installResponse = pluginManagerService.installMarketplaceServerApp(APP_FREE_MARKETPLACE_KEY);
         throwExceptionForError(installResponse);
         Thread.sleep(3000);
-        InstalledAppsResponseModel installedApps = pluginManagerService.getInstalledApps(username, password);
+        InstalledAppsResponseModel installedApps = pluginManagerService.getInstalledApps();
 
         List<PluginResponseModel> allInstalledPlugins = installedApps.getPlugins();
         List<PluginResponseModel> userInstalledPlugins = allInstalledPlugins
@@ -98,7 +84,7 @@ public class JiraServerAppServiceTest extends JiraServerParameterizedTest {
                                                              .collect(Collectors.toList());
         assertTrue(userInstalledPlugins.size() < allInstalledPlugins.size(), "Expected fewer user-installed plugins than total plugins");
 
-        int uninstallResponse = pluginManagerService.uninstallApp(APP_FREE_MARKETPLACE_KEY, username, password);
+        int uninstallResponse = pluginManagerService.uninstallApp(APP_FREE_MARKETPLACE_KEY);
         throwExceptionForError(uninstallResponse);
     }
 


### PR DESCRIPTION
PluginManagerService was relying on credentials independently passed to each method. Our use of http client should now properly handle this.