### PR TITLE
Start adding API that will help with the new Jira field mapping feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ project.ext.moduleName = 'com.synopsys.integration.int-jira-common'
 project.ext.javaUseAutoModuleName = 'true'
 
 group = 'com.synopsys.integration'
-version = '1.2.3-SNAPSHOT'
+version = '2.0.0-SNAPSHOT'
 description = 'A library for using various capabilities of Jira.'
 
 apply plugin: 'com.synopsys.integration.library'

--- a/src/main/java/com/synopsys/integration/jira/common/cloud/builder/IssueRequestModelFieldsBuilder.java
+++ b/src/main/java/com/synopsys/integration/jira/common/cloud/builder/IssueRequestModelFieldsBuilder.java
@@ -66,89 +66,86 @@ public class IssueRequestModelFieldsBuilder implements IssueRequestModelFieldsMa
         return Collections.unmodifiableMap(issueFields);
     }
 
-    public IssueRequestModelFieldsBuilder setSummary(String summary) {
-        issueFields.put(SUMMARY, summary);
+    public IssueRequestModelFieldsBuilder setValue(String key, Object value) {
+        issueFields.put(key, value);
         return this;
+    }
+
+    public IssueRequestModelFieldsBuilder setSummary(String summary) {
+        return setValue(SUMMARY, summary);
     }
 
     public IssueRequestModelFieldsBuilder setIssueType(String issueTypeId) {
-        return setField(ISSUE_TYPE, issueTypeId);
+        return setIdField(ISSUE_TYPE, issueTypeId);
     }
 
     public IssueRequestModelFieldsBuilder setComponents(Collection<String> componentIds) {
-        return setFields(COMPONENTS, componentIds);
+        return setIdFields(COMPONENTS, componentIds);
     }
 
     public IssueRequestModelFieldsBuilder setProject(String projectId) {
-        return setField(PROJECT, projectId);
+        return setIdField(PROJECT, projectId);
     }
 
     public IssueRequestModelFieldsBuilder setDescription(String description) {
-        issueFields.put(DESCRIPTION, description);
-        return this;
+        return setValue(DESCRIPTION, description);
     }
 
     public IssueRequestModelFieldsBuilder setReporterId(String reporterId) {
-        return setField(REPORTER, reporterId);
+        return setIdField(REPORTER, reporterId);
     }
 
     public IssueRequestModelFieldsBuilder setFixVersions(Collection<String> versionIds) {
-        return setFields(FIX_VERSIONS, versionIds);
+        return setIdFields(FIX_VERSIONS, versionIds);
     }
 
     public IssueRequestModelFieldsBuilder setPriority(String priorityId) {
-        return setField(PRIORITY, priorityId);
+        return setIdField(PRIORITY, priorityId);
     }
 
     public IssueRequestModelFieldsBuilder setLabels(Collection<String> labels) {
-        issueFields.put(LABELS, labels);
-        return this;
+        return setValue(LABELS, labels);
     }
 
     public IssueRequestModelFieldsBuilder setTimeTracking(String remainingEstimate, String originalEstimate) {
         Map<String, String> timeTrackingMap = new HashMap<>();
         timeTrackingMap.put("remainingEstimate", remainingEstimate);
         timeTrackingMap.put("originalEstimate", originalEstimate);
-        issueFields.put(TIME_TRACKING, timeTrackingMap);
-        return this;
+        return setValue(TIME_TRACKING, timeTrackingMap);
     }
 
     public IssueRequestModelFieldsBuilder setSecurity(String securityId) {
-        return setField(SECURITY, securityId);
+        return setIdField(SECURITY, securityId);
     }
 
     public IssueRequestModelFieldsBuilder setEnvironment(String environment) {
-        issueFields.put(ENVIRONMENT, environment);
-        return this;
+        return setValue(ENVIRONMENT, environment);
     }
 
     public IssueRequestModelFieldsBuilder setVersions(Collection<String> versionIds) {
-        return setFields(VERSIONS, versionIds);
+        return setIdFields(VERSIONS, versionIds);
     }
 
     public IssueRequestModelFieldsBuilder setDueDate(String dueDate) {
-        issueFields.put(DUE_DATE, dueDate);
-        return this;
+        return setValue(DUE_DATE, dueDate);
     }
 
     public IssueRequestModelFieldsBuilder setAssigneeId(String assigneeId) {
-        return setField(ASSIGNEE, assigneeId);
+        return setIdField(ASSIGNEE, assigneeId);
     }
 
-    private IssueRequestModelFieldsBuilder setField(String key, String value) {
+    private IssueRequestModelFieldsBuilder setIdField(String key, String value) {
         ObjectWithId issueTypeObject = new ObjectWithId(value);
-        issueFields.put(key, issueTypeObject);
-        return this;
+        return setValue(key, issueTypeObject);
     }
 
-    private IssueRequestModelFieldsBuilder setFields(String key, Collection<String> values) {
+    private IssueRequestModelFieldsBuilder setIdFields(String key, Collection<String> values) {
         List<ObjectWithId> newObjects = new ArrayList<>();
         values
             .stream()
             .map(ObjectWithId::new)
             .forEach(newObjects::add);
-        issueFields.put(key, newObjects);
-        return this;
+        return setValue(key, newObjects);
     }
 
     private class ObjectWithId {

--- a/src/main/java/com/synopsys/integration/jira/common/cloud/service/FieldService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/cloud/service/FieldService.java
@@ -27,7 +27,7 @@ import java.util.List;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.jira.common.model.request.FieldRequestModel;
 import com.synopsys.integration.jira.common.model.request.JiraRequestFactory;
-import com.synopsys.integration.jira.common.model.response.FieldResponseModel;
+import com.synopsys.integration.jira.common.model.response.CustomFieldCreationResponseModel;
 import com.synopsys.integration.jira.common.rest.model.JiraRequest;
 import com.synopsys.integration.jira.common.rest.service.JiraApiClient;
 import com.synopsys.integration.rest.HttpUrl;
@@ -41,13 +41,13 @@ public class FieldService {
         this.jiraCloudService = jiraCloudService;
     }
 
-    public List<FieldResponseModel> getUserVisibleFields() throws IntegrationException {
+    public List<CustomFieldCreationResponseModel> getUserVisibleFields() throws IntegrationException {
         JiraRequest request = JiraRequestFactory.createDefaultGetRequest(createApiUri());
-        return jiraCloudService.getList(request, FieldResponseModel.class);
+        return jiraCloudService.getList(request, CustomFieldCreationResponseModel.class);
     }
 
-    public FieldResponseModel createCustomField(FieldRequestModel fieldModel) throws IntegrationException {
-        return jiraCloudService.post(fieldModel, createApiUri(), FieldResponseModel.class);
+    public CustomFieldCreationResponseModel createCustomField(FieldRequestModel fieldModel) throws IntegrationException {
+        return jiraCloudService.post(fieldModel, createApiUri(), CustomFieldCreationResponseModel.class);
     }
 
     private HttpUrl createApiUri() throws IntegrationException {

--- a/src/main/java/com/synopsys/integration/jira/common/cloud/service/IssueService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/cloud/service/IssueService.java
@@ -180,8 +180,19 @@ public class IssueService {
         return statusDetailsComponent;
     }
 
+    public JiraResponse getIssueFields(String projectIdOrKey, String issueTypeId) throws IntegrationException {
+        HttpUrl issueFieldsQueryUri = createIssueFieldsQueryUri(projectIdOrKey, issueTypeId);
+        JiraRequest request = JiraRequestFactory.createDefaultGetRequest(issueFieldsQueryUri);
+        JiraResponse jiraResponse = jiraCloudService.get(request);
+        return jiraResponse;
+    }
+
     private String createApiUri() {
         return jiraCloudService.getBaseUrl() + API_PATH;
+    }
+
+    private HttpUrl createIssueFieldsQueryUri(String projectIdOrKey, String issueTypeId) throws IntegrationException {
+        return new HttpUrl(String.format("%s/createmeta?projectKeys=%s&expand=projects.issuetypes.fields", createApiUri(), projectIdOrKey, issueTypeId));
     }
 
     private HttpUrl createApiIssueUri(String issueIdOrKey) throws IntegrationException {

--- a/src/main/java/com/synopsys/integration/jira/common/cloud/service/IssueService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/cloud/service/IssueService.java
@@ -113,7 +113,6 @@ public class IssueService {
                    .orElseThrow(() -> new JiraPreconditionNotMetException(String.format("Reporter user with email not found; email: %s", reporterEmail)));
     }
 
-    // FIXME Both server and cloud return an object that has far too many fields for the actual data that is returned.
     private IssueCreationResponseModel createIssue(IssueRequestModel requestModel) throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl(createApiUri());
         return jiraCloudService.post(requestModel, httpUrl, IssueCreationResponseModel.class);

--- a/src/main/java/com/synopsys/integration/jira/common/cloud/service/IssueService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/cloud/service/IssueService.java
@@ -42,6 +42,7 @@ import com.synopsys.integration.jira.common.model.request.IssueCommentRequestMod
 import com.synopsys.integration.jira.common.model.request.IssueRequestModel;
 import com.synopsys.integration.jira.common.model.request.JiraRequestFactory;
 import com.synopsys.integration.jira.common.model.response.IssueCommentResponseModel;
+import com.synopsys.integration.jira.common.model.response.IssueCreationResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueTypeResponseModel;
 import com.synopsys.integration.jira.common.model.response.PageOfProjectsResponseModel;
@@ -76,7 +77,7 @@ public class IssueService {
         this.issueTypeService = issueTypeService;
     }
 
-    public IssueResponseModel createIssue(IssueCreationRequestModel requestModel) throws IntegrationException {
+    public IssueCreationResponseModel createIssue(IssueCreationRequestModel requestModel) throws IntegrationException {
         String issueTypeName = requestModel.getIssueTypeName();
         String projectName = requestModel.getProjectName();
         String reporterEmail = requestModel.getReporterEmail();
@@ -113,9 +114,9 @@ public class IssueService {
     }
 
     // FIXME Both server and cloud return an object that has far too many fields for the actual data that is returned.
-    private IssueResponseModel createIssue(IssueRequestModel requestModel) throws IntegrationException {
+    private IssueCreationResponseModel createIssue(IssueRequestModel requestModel) throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl(createApiUri());
-        return jiraCloudService.post(requestModel, httpUrl, IssueResponseModel.class);
+        return jiraCloudService.post(requestModel, httpUrl, IssueCreationResponseModel.class);
     }
 
     public void updateIssue(IssueRequestModel requestModel) throws IntegrationException {
@@ -181,19 +182,8 @@ public class IssueService {
         return statusDetailsComponent;
     }
 
-    public JiraResponse getIssueFields(String projectIdOrKey, String issueTypeId) throws IntegrationException {
-        HttpUrl issueFieldsQueryUri = createIssueFieldsQueryUri(projectIdOrKey, issueTypeId);
-        JiraRequest request = JiraRequestFactory.createDefaultGetRequest(issueFieldsQueryUri);
-        JiraResponse jiraResponse = jiraCloudService.get(request);
-        return jiraResponse;
-    }
-
     private String createApiUri() {
         return jiraCloudService.getBaseUrl() + API_PATH;
-    }
-
-    private HttpUrl createIssueFieldsQueryUri(String projectIdOrKey, String issueTypeId) throws IntegrationException {
-        return new HttpUrl(String.format("%s/createmeta?projectKeys=%s&expand=projects.issuetypes.fields", createApiUri(), projectIdOrKey, issueTypeId));
     }
 
     private HttpUrl createApiIssueUri(String issueIdOrKey) throws IntegrationException {

--- a/src/main/java/com/synopsys/integration/jira/common/cloud/service/IssueService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/cloud/service/IssueService.java
@@ -112,6 +112,7 @@ public class IssueService {
                    .orElseThrow(() -> new JiraPreconditionNotMetException(String.format("Reporter user with email not found; email: %s", reporterEmail)));
     }
 
+    // FIXME Both server and cloud return an object that has far too many fields for the actual data that is returned.
     private IssueResponseModel createIssue(IssueRequestModel requestModel) throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl(createApiUri());
         return jiraCloudService.post(requestModel, httpUrl, IssueResponseModel.class);

--- a/src/main/java/com/synopsys/integration/jira/common/model/response/CustomFieldCreationResponseModel.java
+++ b/src/main/java/com/synopsys/integration/jira/common/model/response/CustomFieldCreationResponseModel.java
@@ -22,73 +22,74 @@
  */
 package com.synopsys.integration.jira.common.model.response;
 
-import java.util.Map;
+import java.util.List;
 
-import com.google.gson.JsonElement;
 import com.synopsys.integration.jira.common.model.JiraResponseModel;
+import com.synopsys.integration.jira.common.model.components.SchemaComponent;
 
-public class IssueTypeResponseModel extends JiraResponseModel {
-    private String self;
+public class CustomFieldCreationResponseModel extends JiraResponseModel {
     private String id;
-    private String description;
-    private String iconUrl;
+    private String key;
     private String name;
-    private Boolean subtask;
-    private Integer avatarId;
-    private Map<String, JsonElement> fields;
+    private Boolean custom;
+    private Boolean navigable;
+    private Boolean searchable;
+    private List<String> clauseNames;
+    private SchemaComponent schema;
 
-    public IssueTypeResponseModel() {
+    public CustomFieldCreationResponseModel() {
     }
 
-    public IssueTypeResponseModel(
-        String self,
+    public CustomFieldCreationResponseModel(
         String id,
-        String description,
-        String iconUrl,
+        String key,
         String name,
-        Boolean subtask,
-        Integer avatarId,
-        Map<String, JsonElement> fields
+        Boolean custom,
+        Boolean navigable,
+        Boolean searchable,
+        List<String> clauseNames,
+        SchemaComponent schema
     ) {
-        this.self = self;
         this.id = id;
-        this.description = description;
-        this.iconUrl = iconUrl;
+        this.key = key;
         this.name = name;
-        this.subtask = subtask;
-        this.avatarId = avatarId;
-        this.fields = fields;
-    }
-
-    public String getSelf() {
-        return self;
+        this.custom = custom;
+        this.navigable = navigable;
+        this.searchable = searchable;
+        this.clauseNames = clauseNames;
+        this.schema = schema;
     }
 
     public String getId() {
         return id;
     }
 
-    public String getDescription() {
-        return description;
-    }
-
-    public String getIconUrl() {
-        return iconUrl;
+    public String getKey() {
+        return key;
     }
 
     public String getName() {
         return name;
     }
 
-    public Boolean getSubtask() {
-        return subtask;
+    public Boolean getCustom() {
+        return custom;
     }
 
-    public Integer getAvatarId() {
-        return avatarId;
+    public Boolean getNavigable() {
+        return navigable;
     }
 
-    public Map<String, JsonElement> getFields() {
-        return fields;
+    public Boolean getSearchable() {
+        return searchable;
     }
+
+    public List<String> getClauseNames() {
+        return clauseNames;
+    }
+
+    public SchemaComponent getSchema() {
+        return schema;
+    }
+
 }

--- a/src/main/java/com/synopsys/integration/jira/common/model/response/FieldResponseModel.java
+++ b/src/main/java/com/synopsys/integration/jira/common/model/response/FieldResponseModel.java
@@ -24,72 +24,62 @@ package com.synopsys.integration.jira.common.model.response;
 
 import java.util.List;
 
+import com.google.gson.JsonElement;
 import com.synopsys.integration.jira.common.model.JiraResponseModel;
-import com.synopsys.integration.jira.common.model.components.SchemaComponent;
 
 public class FieldResponseModel extends JiraResponseModel {
-    private String id;
-    private String key;
+    private boolean required;
+    private JsonElement schema;
     private String name;
-    private Boolean custom;
-    private Boolean navigable;
-    private Boolean searchable;
-    private List<String> clauseNames;
-    private SchemaComponent schema;
+    private String key;
+    private boolean hasDefaultValue;
+    private List<String> operations;
+    private List<JsonElement> allowedValues;
 
     public FieldResponseModel() {
     }
 
-    public FieldResponseModel(
-        String id,
-        String key,
+    public FieldResponseModel(boolean required,
+        JsonElement schema,
         String name,
-        Boolean custom,
-        Boolean navigable,
-        Boolean searchable,
-        List<String> clauseNames,
-        SchemaComponent schema
-    ) {
-        this.id = id;
-        this.key = key;
-        this.name = name;
-        this.custom = custom;
-        this.navigable = navigable;
-        this.searchable = searchable;
-        this.clauseNames = clauseNames;
+        String key,
+        boolean hasDefaultValue,
+        List<String> operations,
+        List<JsonElement> allowedValues) {
+        this.required = required;
         this.schema = schema;
+        this.name = name;
+        this.key = key;
+        this.hasDefaultValue = hasDefaultValue;
+        this.operations = operations;
+        this.allowedValues = allowedValues;
     }
 
-    public String getId() {
-        return id;
+    public boolean isRequired() {
+        return required;
     }
 
-    public String getKey() {
-        return key;
+    public JsonElement getSchema() {
+        return schema;
     }
 
     public String getName() {
         return name;
     }
 
-    public Boolean getCustom() {
-        return custom;
+    public String getKey() {
+        return key;
     }
 
-    public Boolean getNavigable() {
-        return navigable;
+    public boolean isHasDefaultValue() {
+        return hasDefaultValue;
     }
 
-    public Boolean getSearchable() {
-        return searchable;
+    public List<String> getOperations() {
+        return operations;
     }
 
-    public List<String> getClauseNames() {
-        return clauseNames;
+    public List<JsonElement> getAllowedValues() {
+        return allowedValues;
     }
-
-    public SchemaComponent getSchema() {
-        return schema;
-    }
-
 }

--- a/src/main/java/com/synopsys/integration/jira/common/model/response/IssueCreatemetaFieldResponseModel.java
+++ b/src/main/java/com/synopsys/integration/jira/common/model/response/IssueCreatemetaFieldResponseModel.java
@@ -26,26 +26,29 @@ import java.util.List;
 
 import com.google.gson.JsonElement;
 import com.synopsys.integration.jira.common.model.JiraResponseModel;
+import com.synopsys.integration.jira.common.model.components.SchemaComponent;
 
-public class FieldResponseModel extends JiraResponseModel {
+public class IssueCreatemetaFieldResponseModel extends JiraResponseModel {
     private boolean required;
-    private JsonElement schema;
+    private SchemaComponent schema;
     private String name;
     private String key;
     private boolean hasDefaultValue;
     private List<String> operations;
     private List<JsonElement> allowedValues;
 
-    public FieldResponseModel() {
+    public IssueCreatemetaFieldResponseModel() {
     }
 
-    public FieldResponseModel(boolean required,
-        JsonElement schema,
+    public IssueCreatemetaFieldResponseModel(
+        boolean required,
+        SchemaComponent schema,
         String name,
         String key,
         boolean hasDefaultValue,
         List<String> operations,
-        List<JsonElement> allowedValues) {
+        List<JsonElement> allowedValues
+    ) {
         this.required = required;
         this.schema = schema;
         this.name = name;
@@ -59,7 +62,7 @@ public class FieldResponseModel extends JiraResponseModel {
         return required;
     }
 
-    public JsonElement getSchema() {
+    public SchemaComponent getSchema() {
         return schema;
     }
 

--- a/src/main/java/com/synopsys/integration/jira/common/model/response/IssueCreationResponseModel.java
+++ b/src/main/java/com/synopsys/integration/jira/common/model/response/IssueCreationResponseModel.java
@@ -1,0 +1,52 @@
+/**
+ * int-jira-common
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.jira.common.model.response;
+
+import com.synopsys.integration.jira.common.model.JiraResponseModel;
+
+public class IssueCreationResponseModel extends JiraResponseModel {
+    private String id;
+    private String self;
+    private String key;
+
+    public IssueCreationResponseModel() {
+    }
+
+    public IssueCreationResponseModel(String id, String self, String key) {
+        this.id = id;
+        this.self = self;
+        this.key = key;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getSelf() {
+        return self;
+    }
+
+    public String getKey() {
+        return key;
+    }
+}

--- a/src/main/java/com/synopsys/integration/jira/common/rest/service/IssueMetaDataService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/rest/service/IssueMetaDataService.java
@@ -45,6 +45,12 @@ public class IssueMetaDataService {
         return jiraApiClient.get(request, IssueCreateMetadataResponseModel.class);
     }
 
+    public IssueCreateMetadataResponseModel getCreateMetadataProjectIssueTypeFields(String projectKeyOrId, String issueTypeId) throws IntegrationException {
+        HttpUrl issueFieldsQueryUri = createIssueFieldsQueryUri(projectKeyOrId, issueTypeId);
+        JiraRequest request = JiraRequestFactory.createDefaultGetRequest(issueFieldsQueryUri);
+        return jiraApiClient.get(request, IssueCreateMetadataResponseModel.class);
+    }
+
     public boolean doesProjectContainIssueType(String projectName, String issueType) throws IntegrationException {
         IssueCreateMetadataResponseModel response = getCreateMetadata();
 
@@ -69,5 +75,9 @@ public class IssueMetaDataService {
 
     private HttpUrl createApiUri() throws IntegrationException {
         return new HttpUrl(jiraApiClient.getBaseUrl() + API_PATH);
+    }
+
+    private HttpUrl createIssueFieldsQueryUri(String projectIdOrKey, String issueTypeId) throws IntegrationException {
+        return new HttpUrl(String.format("%s?projectKeys=%s&expand=projects.issuetypes.fields", createApiUri(), projectIdOrKey, issueTypeId));
     }
 }

--- a/src/main/java/com/synopsys/integration/jira/common/server/builder/IssueRequestModelFieldsBuilder.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/builder/IssueRequestModelFieldsBuilder.java
@@ -1,8 +1,8 @@
 /**
  * int-jira-common
- *
+ * <p>
  * Copyright (c) 2020 Synopsys, Inc.
- *
+ * <p>
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
@@ -10,9 +10,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -66,8 +66,13 @@ public class IssueRequestModelFieldsBuilder implements IssueRequestModelFieldsMa
         return Collections.unmodifiableMap(issueFields);
     }
 
+    public IssueRequestModelFieldsBuilder setField(String key, Object value) {
+        issueFields.put(key, value);
+        return this;
+    }
+
     public IssueRequestModelFieldsBuilder setSummary(String summary) {
-        issueFields.put(SUMMARY, summary);
+        setField(SUMMARY, summary);
         return this;
     }
 
@@ -84,7 +89,7 @@ public class IssueRequestModelFieldsBuilder implements IssueRequestModelFieldsMa
     }
 
     public IssueRequestModelFieldsBuilder setDescription(String description) {
-        issueFields.put(DESCRIPTION, description);
+        setField(DESCRIPTION, description);
         return this;
     }
 
@@ -101,7 +106,7 @@ public class IssueRequestModelFieldsBuilder implements IssueRequestModelFieldsMa
     }
 
     public IssueRequestModelFieldsBuilder setLabels(Collection<String> labels) {
-        issueFields.put(LABELS, labels);
+        setField(LABELS, labels);
         return this;
     }
 

--- a/src/main/java/com/synopsys/integration/jira/common/server/builder/IssueRequestModelFieldsBuilder.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/builder/IssueRequestModelFieldsBuilder.java
@@ -1,8 +1,8 @@
 /**
  * int-jira-common
- * <p>
+ *
  * Copyright (c) 2020 Synopsys, Inc.
- * <p>
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
@@ -10,9 +10,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/main/java/com/synopsys/integration/jira/common/server/model/VersionRequestModel.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/model/VersionRequestModel.java
@@ -42,7 +42,8 @@ public class VersionRequestModel extends JiraRequestModel {
         this.projectId = projectId;
     }
 
-    public VersionRequestModel(String description,
+    public VersionRequestModel(
+        String description,
         String name,
         boolean archived,
         boolean released,

--- a/src/main/java/com/synopsys/integration/jira/common/server/model/VersionRequestModel.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/model/VersionRequestModel.java
@@ -1,0 +1,95 @@
+/**
+ * int-jira-common
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.jira.common.server.model;
+
+import com.synopsys.integration.jira.common.model.request.JiraRequestModel;
+
+public class VersionRequestModel extends JiraRequestModel {
+    private String description;
+    private String name;
+    private boolean archived;
+    private boolean released;
+    private String releaseDate;
+    private String userReleaseDate;
+    private String project;
+    private String projectId;
+
+    public VersionRequestModel() {
+    }
+
+    public VersionRequestModel(String name, String projectId) {
+        this.name = name;
+        this.projectId = projectId;
+    }
+
+    public VersionRequestModel(String description,
+        String name,
+        boolean archived,
+        boolean released,
+        String releaseDate,
+        String userReleaseDate,
+        String project,
+        String projectId
+    ) {
+        this.description = description;
+        this.name = name;
+        this.archived = archived;
+        this.released = released;
+        this.releaseDate = releaseDate;
+        this.userReleaseDate = userReleaseDate;
+        this.project = project;
+        this.projectId = projectId;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isArchived() {
+        return archived;
+    }
+
+    public boolean isReleased() {
+        return released;
+    }
+
+    public String getReleaseDate() {
+        return releaseDate;
+    }
+
+    public String getUserReleaseDate() {
+        return userReleaseDate;
+    }
+
+    public String getProject() {
+        return project;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+}

--- a/src/main/java/com/synopsys/integration/jira/common/server/model/VersionResponseModel.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/model/VersionResponseModel.java
@@ -1,0 +1,77 @@
+/**
+ * int-jira-common
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.jira.common.server.model;
+
+import com.synopsys.integration.jira.common.model.JiraResponseModel;
+
+public class VersionResponseModel extends JiraResponseModel {
+    private String self;
+    private String id;
+    private String name;
+    private boolean archived;
+    private boolean released;
+    private String projectId;
+
+    public VersionResponseModel() {
+    }
+
+    public VersionResponseModel(
+        String self,
+        String id,
+        String name,
+        boolean archived,
+        boolean released,
+        String projectId
+    ) {
+        this.self = self;
+        this.id = id;
+        this.name = name;
+        this.archived = archived;
+        this.released = released;
+        this.projectId = projectId;
+    }
+
+    public String getSelf() {
+        return self;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isArchived() {
+        return archived;
+    }
+
+    public boolean isReleased() {
+        return released;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+}

--- a/src/main/java/com/synopsys/integration/jira/common/server/service/IssueService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/service/IssueService.java
@@ -174,8 +174,20 @@ public class IssueService {
         return statusDetailsComponent;
     }
 
+    public JiraResponse getIssueFields(String projectIdOrKey, String issueTypeId) throws IntegrationException {
+        HttpUrl issueFieldsQueryUri = createIssueFieldsQueryUri(projectIdOrKey, issueTypeId);
+        JiraRequest request = JiraRequestFactory.createDefaultGetRequest(issueFieldsQueryUri);
+        JiraResponse jiraResponse = jiraApiClient.get(request);
+        return jiraResponse;
+    }
+
     private String createApiUri() {
         return jiraApiClient.getBaseUrl() + API_PATH;
+    }
+
+    private HttpUrl createIssueFieldsQueryUri(String projectIdOrKey, String issueTypeId) throws IntegrationException {
+        //        return new HttpUrl(String.format("%s/createmeta?projectKeys=%s&expand=projects.issuetypes.fields", createApiUri(), projectIdOrKey, issueTypeId));
+        return new HttpUrl(String.format("%s/createmeta/%s/issuetypes/%s", createApiUri(), projectIdOrKey, issueTypeId));
     }
 
     private HttpUrl createApiIssueUri(String issueIdOrKey) throws IntegrationException {

--- a/src/main/java/com/synopsys/integration/jira/common/server/service/IssueService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/service/IssueService.java
@@ -1,8 +1,8 @@
 /**
  * int-jira-common
- * <p>
+ *
  * Copyright (c) 2020 Synopsys, Inc.
- * <p>
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
@@ -10,9 +10,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.gson.JsonObject;
-
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.jira.common.exception.JiraPreconditionNotMetException;
 import com.synopsys.integration.jira.common.model.components.FieldUpdateOperationComponent;
@@ -39,6 +38,7 @@ import com.synopsys.integration.jira.common.model.request.IssueRequestModel;
 import com.synopsys.integration.jira.common.model.request.JiraRequestFactory;
 import com.synopsys.integration.jira.common.model.request.builder.IssueRequestModelFieldsMapBuilder;
 import com.synopsys.integration.jira.common.model.response.IssueCommentResponseModel;
+import com.synopsys.integration.jira.common.model.response.IssueCreationResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueTypeResponseModel;
 import com.synopsys.integration.jira.common.model.response.TransitionsResponseModel;
@@ -74,27 +74,26 @@ public class IssueService {
         this.issueTypeService = issueTypeService;
     }
 
-    // FIXME Both server and cloud return an object that has far too many fields for the actual data that is returned.
-    public IssueResponseModel createIssue(IssueCreationRequestModel requestModel) throws IntegrationException {
+    public IssueCreationResponseModel createIssue(IssueCreationRequestModel requestModel) throws IntegrationException {
         String issueTypeName = requestModel.getIssueTypeName();
         String projectName = requestModel.getProjectName();
         String reporter = requestModel.getReporterUsername();
 
         IssueTypeResponseModel foundIssueType = issueTypeService.getAllIssueTypes().stream()
-            .filter(issueType -> issueType.getName().equalsIgnoreCase(issueTypeName))
-            .findFirst()
-            .orElseThrow(() -> new JiraPreconditionNotMetException(String.format("Issue type not found; issue type %s", issueTypeName)));
+                                                    .filter(issueType -> issueType.getName().equalsIgnoreCase(issueTypeName))
+                                                    .findFirst()
+                                                    .orElseThrow(() -> new JiraPreconditionNotMetException(String.format("Issue type not found; issue type %s", issueTypeName)));
         UserDetailsResponseModel foundUserDetails = userSearchService.findUserByUsername(reporter)
-            .orElseThrow(() -> new JiraPreconditionNotMetException(String.format("Reporter user with email not found; email: %s", reporter)));
+                                                        .orElseThrow(() -> new JiraPreconditionNotMetException(String.format("Reporter user with email not found; email: %s", reporter)));
         List<ProjectComponent> projects = projectService.getProjectsByName(projectName);
         ProjectComponent foundProject = projects.stream()
-            .findFirst()
-            .orElseThrow(() -> new JiraPreconditionNotMetException(String.format("Project not found; project name: %s", projectName)));
+                                            .findFirst()
+                                            .orElseThrow(() -> new JiraPreconditionNotMetException(String.format("Project not found; project name: %s", projectName)));
 
         return createIssue(foundIssueType.getId(), foundUserDetails.getName(), foundProject.getId(), requestModel.getFieldsBuilder());
     }
 
-    public IssueResponseModel createIssue(String issueTypeId, String reporterUserName, String projectId, IssueRequestModelFieldsMapBuilder issueRequestModelFieldsMapBuilder) throws IntegrationException {
+    public IssueCreationResponseModel createIssue(String issueTypeId, String reporterUserName, String projectId, IssueRequestModelFieldsMapBuilder issueRequestModelFieldsMapBuilder) throws IntegrationException {
 
         IssueRequestModelFieldsBuilder fieldsBuilder = new IssueRequestModelFieldsBuilder();
         fieldsBuilder.copyFields(issueRequestModelFieldsMapBuilder);
@@ -108,9 +107,9 @@ public class IssueService {
         return createIssue(issueRequestModel);
     }
 
-    private IssueResponseModel createIssue(IssueRequestModel requestModel) throws IntegrationException {
+    private IssueCreationResponseModel createIssue(IssueRequestModel requestModel) throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl(createApiUri());
-        return jiraApiClient.post(requestModel, httpUrl, IssueResponseModel.class);
+        return jiraApiClient.post(requestModel, httpUrl, IssueCreationResponseModel.class);
     }
 
     public void updateIssue(IssueRequestModel requestModel) throws IntegrationException {
@@ -125,9 +124,9 @@ public class IssueService {
     public IssueResponseModel getIssue(String issueIdOrKey) throws IntegrationException {
         HttpUrl uri = createApiIssueUri(issueIdOrKey);
         JiraRequest request = JiraRequestFactory.createDefaultBuilder()
-            .url(uri)
-            .addQueryParameter("properties", "*all")
-            .build();
+                                  .url(uri)
+                                  .addQueryParameter("properties", "*all")
+                                  .build();
         return jiraApiClient.get(request, IssueResponseModel.class);
     }
 

--- a/src/main/java/com/synopsys/integration/jira/common/server/service/IssueService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/service/IssueService.java
@@ -175,20 +175,8 @@ public class IssueService {
         return statusDetailsComponent;
     }
 
-    public JiraResponse getIssueFields(String projectIdOrKey, String issueTypeId) throws IntegrationException {
-        HttpUrl issueFieldsQueryUri = createIssueFieldsQueryUri(projectIdOrKey, issueTypeId);
-        JiraRequest request = JiraRequestFactory.createDefaultGetRequest(issueFieldsQueryUri);
-        JiraResponse jiraResponse = jiraApiClient.get(request);
-        return jiraResponse;
-    }
-
     private String createApiUri() {
         return jiraApiClient.getBaseUrl() + API_PATH;
-    }
-
-    private HttpUrl createIssueFieldsQueryUri(String projectIdOrKey, String issueTypeId) throws IntegrationException {
-        //        return new HttpUrl(String.format("%s/createmeta?projectKeys=%s&expand=projects.issuetypes.fields", createApiUri(), projectIdOrKey, issueTypeId));
-        return new HttpUrl(String.format("%s/createmeta/%s/issuetypes/%s", createApiUri(), projectIdOrKey, issueTypeId));
     }
 
     private HttpUrl createApiIssueUri(String issueIdOrKey) throws IntegrationException {

--- a/src/main/java/com/synopsys/integration/jira/common/server/service/IssueService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/service/IssueService.java
@@ -1,8 +1,8 @@
 /**
  * int-jira-common
- *
+ * <p>
  * Copyright (c) 2020 Synopsys, Inc.
- *
+ * <p>
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
@@ -10,9 +10,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.gson.JsonObject;
+
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.jira.common.exception.JiraPreconditionNotMetException;
 import com.synopsys.integration.jira.common.model.components.FieldUpdateOperationComponent;
@@ -73,21 +74,22 @@ public class IssueService {
         this.issueTypeService = issueTypeService;
     }
 
+    // FIXME Both server and cloud return an object that has far too many fields for the actual data that is returned.
     public IssueResponseModel createIssue(IssueCreationRequestModel requestModel) throws IntegrationException {
         String issueTypeName = requestModel.getIssueTypeName();
         String projectName = requestModel.getProjectName();
         String reporter = requestModel.getReporterUsername();
 
         IssueTypeResponseModel foundIssueType = issueTypeService.getAllIssueTypes().stream()
-                                                    .filter(issueType -> issueType.getName().equalsIgnoreCase(issueTypeName))
-                                                    .findFirst()
-                                                    .orElseThrow(() -> new JiraPreconditionNotMetException(String.format("Issue type not found; issue type %s", issueTypeName)));
+            .filter(issueType -> issueType.getName().equalsIgnoreCase(issueTypeName))
+            .findFirst()
+            .orElseThrow(() -> new JiraPreconditionNotMetException(String.format("Issue type not found; issue type %s", issueTypeName)));
         UserDetailsResponseModel foundUserDetails = userSearchService.findUserByUsername(reporter)
-                                                        .orElseThrow(() -> new JiraPreconditionNotMetException(String.format("Reporter user with email not found; email: %s", reporter)));
+            .orElseThrow(() -> new JiraPreconditionNotMetException(String.format("Reporter user with email not found; email: %s", reporter)));
         List<ProjectComponent> projects = projectService.getProjectsByName(projectName);
         ProjectComponent foundProject = projects.stream()
-                                            .findFirst()
-                                            .orElseThrow(() -> new JiraPreconditionNotMetException(String.format("Project not found; project name: %s", projectName)));
+            .findFirst()
+            .orElseThrow(() -> new JiraPreconditionNotMetException(String.format("Project not found; project name: %s", projectName)));
 
         return createIssue(foundIssueType.getId(), foundUserDetails.getName(), foundProject.getId(), requestModel.getFieldsBuilder());
     }
@@ -123,9 +125,9 @@ public class IssueService {
     public IssueResponseModel getIssue(String issueIdOrKey) throws IntegrationException {
         HttpUrl uri = createApiIssueUri(issueIdOrKey);
         JiraRequest request = JiraRequestFactory.createDefaultBuilder()
-                                  .url(uri)
-                                  .addQueryParameter("properties", "*all")
-                                  .build();
+            .url(uri)
+            .addQueryParameter("properties", "*all")
+            .build();
         return jiraApiClient.get(request, IssueResponseModel.class);
     }
 

--- a/src/main/java/com/synopsys/integration/jira/common/server/service/JiraServerServiceFactory.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/service/JiraServerServiceFactory.java
@@ -53,4 +53,8 @@ public class JiraServerServiceFactory extends CommonServiceFactory {
         return new MyPermissionsService(getJiraApiClient());
     }
 
+    public VersionService createVersionService() {
+        return new VersionService(getJiraApiClient());
+    }
+
 }

--- a/src/main/java/com/synopsys/integration/jira/common/server/service/VersionService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/service/VersionService.java
@@ -1,0 +1,70 @@
+/**
+ * int-jira-common
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.integration.jira.common.server.service;
+
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.jira.common.model.request.JiraRequestFactory;
+import com.synopsys.integration.jira.common.rest.model.JiraRequest;
+import com.synopsys.integration.jira.common.rest.service.JiraApiClient;
+import com.synopsys.integration.jira.common.server.model.VersionRequestModel;
+import com.synopsys.integration.jira.common.server.model.VersionResponseModel;
+import com.synopsys.integration.rest.HttpUrl;
+
+public class VersionService {
+    public static final String API_PATH = "/rest/api/2/version";
+
+    private final JiraApiClient jiraApiClient;
+
+    public VersionService(JiraApiClient jiraApiClient) {
+        this.jiraApiClient = jiraApiClient;
+    }
+
+    public VersionResponseModel getVersion(String id) throws IntegrationException {
+        HttpUrl url = createApiUrlWithId(id);
+        JiraRequest request = JiraRequestFactory.createDefaultGetRequest(url);
+        return jiraApiClient.get(request, VersionResponseModel.class);
+    }
+
+    public void deleteVersion(String id) throws IntegrationException {
+        HttpUrl url = createApiUrlWithId(id);
+        jiraApiClient.delete(url);
+    }
+
+    public VersionResponseModel createVersion(String name, String projectId) throws IntegrationException {
+        HttpUrl url = createApiUrl();
+        return jiraApiClient.post(new VersionRequestModel(name, projectId), url, VersionResponseModel.class);
+    }
+
+    public VersionResponseModel createVersion(VersionRequestModel versionRequestModel) throws IntegrationException {
+        HttpUrl url = createApiUrl();
+        return jiraApiClient.post(versionRequestModel, url, VersionResponseModel.class);
+    }
+
+    private HttpUrl createApiUrl() throws IntegrationException {
+        return new HttpUrl(jiraApiClient.getBaseUrl() + API_PATH);
+    }
+
+    private HttpUrl createApiUrlWithId(String id) throws IntegrationException {
+        return new HttpUrl(String.format("%s/%s", createApiUrl(), id));
+    }
+}

--- a/src/test/java/com/synopsys/integration/jira/common/cloud/service/FieldServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/cloud/service/FieldServiceTest.java
@@ -1,0 +1,26 @@
+package com.synopsys.integration.jira.common.cloud.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.jira.common.cloud.JiraCloudParameterizedTest;
+import com.synopsys.integration.jira.common.model.response.FieldResponseModel;
+import com.synopsys.integration.jira.common.rest.JiraHttpClient;
+
+public class FieldServiceTest extends JiraCloudParameterizedTest {
+
+    @ParameterizedTest
+    @MethodSource("getParameters")
+    public void getFieldsTest(JiraHttpClient jiraHttpClient) throws IntegrationException {
+        JiraCloudServiceFactory serviceFactory = JiraCloudServiceTestUtility.createServiceFactory(jiraHttpClient);
+        FieldService fieldService = serviceFactory.createFieldService();
+
+        List<FieldResponseModel> userVisibleFields = fieldService.getUserVisibleFields();
+        assertTrue(userVisibleFields.size() > 0);
+    }
+}

--- a/src/test/java/com/synopsys/integration/jira/common/cloud/service/FieldServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/cloud/service/FieldServiceTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.jira.common.cloud.JiraCloudParameterizedTest;
-import com.synopsys.integration.jira.common.model.response.FieldResponseModel;
+import com.synopsys.integration.jira.common.model.response.CustomFieldCreationResponseModel;
 import com.synopsys.integration.jira.common.rest.JiraHttpClient;
 
 public class FieldServiceTest extends JiraCloudParameterizedTest {
@@ -20,7 +20,7 @@ public class FieldServiceTest extends JiraCloudParameterizedTest {
         JiraCloudServiceFactory serviceFactory = JiraCloudServiceTestUtility.createServiceFactory(jiraHttpClient);
         FieldService fieldService = serviceFactory.createFieldService();
 
-        List<FieldResponseModel> userVisibleFields = fieldService.getUserVisibleFields();
+        List<CustomFieldCreationResponseModel> userVisibleFields = fieldService.getUserVisibleFields();
         assertTrue(userVisibleFields.size() > 0);
     }
 }

--- a/src/test/java/com/synopsys/integration/jira/common/cloud/service/IssueSearchServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/cloud/service/IssueSearchServiceTest.java
@@ -16,6 +16,7 @@ import com.synopsys.integration.jira.common.cloud.model.IssueSearchResponseModel
 import com.synopsys.integration.jira.common.model.EntityProperty;
 import com.synopsys.integration.jira.common.model.components.ProjectComponent;
 import com.synopsys.integration.jira.common.model.request.IssueCommentRequestModel;
+import com.synopsys.integration.jira.common.model.response.IssueCreationResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueResponseModel;
 import com.synopsys.integration.jira.common.model.response.PageOfProjectsResponseModel;
 import com.synopsys.integration.jira.common.model.response.UserDetailsResponseModel;
@@ -52,7 +53,7 @@ public class IssueSearchServiceTest extends JiraCloudParameterizedTest {
         String issueType = "bug";
         List<EntityProperty> properties = new LinkedList<>();
         IssueCreationRequestModel requestModel = new IssueCreationRequestModel(userDetails.getEmailAddress(), issueType, project.getName(), fieldsBuilder, properties);
-        IssueResponseModel createdIssue = issueService.createIssue(requestModel);
+        IssueCreationResponseModel createdIssue = issueService.createIssue(requestModel);
 
         IssueSearchResponseModel foundIssues = issueSearchService.findIssuesByDescription(project.getKey(), issueType, uniqueIdString);
 
@@ -91,7 +92,7 @@ public class IssueSearchServiceTest extends JiraCloudParameterizedTest {
         IssueCreationRequestModel requestModel = new IssueCreationRequestModel(userDetails.getEmailAddress(), issueType, project.getName(), fieldsBuilder, properties);
 
         // create an issue
-        IssueResponseModel createdIssue = issueService.createIssue(requestModel);
+        IssueCreationResponseModel createdIssue = issueService.createIssue(requestModel);
         IssueCommentRequestModel commentRequestModel = new IssueCommentRequestModel(createdIssue.getId(), commentValue, null, null, null);
         issueService.addComment(commentRequestModel);
 
@@ -135,7 +136,7 @@ public class IssueSearchServiceTest extends JiraCloudParameterizedTest {
         IssueCreationRequestModel requestModel = new IssueCreationRequestModel(userDetails.getEmailAddress(), issueType, project.getName(), fieldsBuilder, properties);
 
         // create an issue
-        IssueResponseModel createdIssue = issueService.createIssue(requestModel);
+        IssueCreationResponseModel createdIssue = issueService.createIssue(requestModel);
 
         IssueCommentRequestModel firstComment = new IssueCommentRequestModel(createdIssue.getId(), "First comment.", null, null, null);
         issueService.addComment(firstComment);
@@ -188,7 +189,7 @@ public class IssueSearchServiceTest extends JiraCloudParameterizedTest {
         IssueCreationRequestModel requestModel = new IssueCreationRequestModel(userDetails.getEmailAddress(), issueType, project.getName(), fieldsBuilder, properties);
 
         // create an issue
-        IssueResponseModel createdIssue = issueService.createIssue(requestModel);
+        IssueCreationResponseModel createdIssue = issueService.createIssue(requestModel);
 
         IssueCommentRequestModel firstComment = new IssueCommentRequestModel(createdIssue.getId(), "First comment.", null, null, null);
         issueService.addComment(firstComment);

--- a/src/test/java/com/synopsys/integration/jira/common/cloud/service/IssueServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/cloud/service/IssueServiceTest.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -31,14 +30,12 @@ import com.synopsys.integration.jira.common.model.components.StatusDetailsCompon
 import com.synopsys.integration.jira.common.model.components.TransitionComponent;
 import com.synopsys.integration.jira.common.model.request.IssueCommentRequestModel;
 import com.synopsys.integration.jira.common.model.request.IssueRequestModel;
+import com.synopsys.integration.jira.common.model.response.IssueCreationResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueResponseModel;
-import com.synopsys.integration.jira.common.model.response.IssueTypeResponseModel;
 import com.synopsys.integration.jira.common.model.response.PageOfProjectsResponseModel;
 import com.synopsys.integration.jira.common.model.response.TransitionsResponseModel;
 import com.synopsys.integration.jira.common.model.response.UserDetailsResponseModel;
 import com.synopsys.integration.jira.common.rest.JiraHttpClient;
-import com.synopsys.integration.jira.common.rest.model.JiraResponse;
-import com.synopsys.integration.jira.common.rest.service.IssueTypeService;
 
 public class IssueServiceTest extends JiraCloudParameterizedTest {
 
@@ -50,7 +47,7 @@ public class IssueServiceTest extends JiraCloudParameterizedTest {
         IssueService issueService = serviceFactory.createIssueService();
 
         // create an issue
-        IssueResponseModel createdIssue = createIssue(serviceFactory);
+        IssueCreationResponseModel createdIssue = createIssue(serviceFactory);
         IssueResponseModel foundIssue = issueService.getIssue(createdIssue.getId());
         // delete the issue
         issueService.deleteIssue(createdIssue.getId());
@@ -147,7 +144,7 @@ public class IssueServiceTest extends JiraCloudParameterizedTest {
                                                    .findFirst()
                                                    .orElseThrow(() -> new IllegalStateException("Jira User not found"));
         // create an issue
-        IssueResponseModel createdIssue = createIssue(serviceFactory);
+        IssueCreationResponseModel createdIssue = createIssue(serviceFactory);
         IssueResponseModel foundIssue = issueService.getIssue(createdIssue.getId());
         IssueRequestModelFieldsBuilder fieldsBuilder = new IssueRequestModelFieldsBuilder();
         fieldsBuilder.setAssigneeId(userDetails.getAccountId());
@@ -180,7 +177,7 @@ public class IssueServiceTest extends JiraCloudParameterizedTest {
         IssueService issueService = serviceFactory.createIssueService();
 
         // create an issue
-        IssueResponseModel createdIssue = createIssue(serviceFactory);
+        IssueCreationResponseModel createdIssue = createIssue(serviceFactory);
         IssueResponseModel foundIssue = issueService.getIssue(createdIssue.getId());
         UUID uniqueId = UUID.randomUUID();
         IssueCommentRequestModel issueCommentModel = new IssueCommentRequestModel(foundIssue.getId(), uniqueId.toString(), null, true, null);
@@ -204,7 +201,7 @@ public class IssueServiceTest extends JiraCloudParameterizedTest {
         IssueService issueService = serviceFactory.createIssueService();
 
         // create an issue
-        IssueResponseModel createdIssue = createIssue(serviceFactory);
+        IssueCreationResponseModel createdIssue = createIssue(serviceFactory);
         String issueId = createdIssue.getId();
         IssueResponseModel foundIssue = issueService.getIssue(issueId);
 
@@ -229,7 +226,7 @@ public class IssueServiceTest extends JiraCloudParameterizedTest {
                                                    .orElseThrow(() -> new IllegalStateException("Jira User not found"));
 
         // create an issue
-        IssueResponseModel createdIssue = createIssue(serviceFactory);
+        IssueCreationResponseModel createdIssue = createIssue(serviceFactory);
         IssueResponseModel foundIssue = issueService.getIssue(createdIssue.getId());
 
         IssueRequestModelFieldsBuilder fieldsBuilder = new IssueRequestModelFieldsBuilder();
@@ -254,35 +251,7 @@ public class IssueServiceTest extends JiraCloudParameterizedTest {
         assertNotEquals(foundIssue.getFields().getUpdated(), foundIssueWithTransition.getFields().getUpdated());
     }
 
-    @ParameterizedTest
-    @MethodSource("getParameters")
-    public void testIssueFields(JiraHttpClient jiraHttpClient) throws IntegrationException {
-        JiraCloudServiceTestUtility.validateConfiguration();
-        JiraCloudServiceFactory serviceFactory = JiraCloudServiceTestUtility.createServiceFactory(jiraHttpClient);
-        IssueService issueService = serviceFactory.createIssueService();
-        IssueTypeService issueTypeService = serviceFactory.createIssueTypeService();
-        ProjectService projectService = serviceFactory.createProjectService();
-
-        String testProject = JiraCloudServiceTestUtility.getTestProject();
-        String projectKey = projectService.getProjectsByName(testProject)
-                                .getProjects()
-                                .stream()
-                                .findFirst()
-                                .map(ProjectComponent::getKey)
-                                .orElseThrow(() -> new IntegrationException("Expected to find project"));
-
-        String issueId = issueTypeService.getAllIssueTypes()
-                             .stream()
-                             .filter(issueType -> "Task".equalsIgnoreCase(issueType.getName()))
-                             .map(IssueTypeResponseModel::getId)
-                             .findFirst()
-                             .orElseThrow(() -> new IntegrationException("Expected to find issue type task"));
-
-        JiraResponse issueFields = issueService.getIssueFields(projectKey, issueId);
-        assertTrue(StringUtils.isNotBlank(issueFields.getContent()));
-    }
-
-    private IssueResponseModel createIssue(JiraCloudServiceFactory serviceFactory) throws IntegrationException {
+    private IssueCreationResponseModel createIssue(JiraCloudServiceFactory serviceFactory) throws IntegrationException {
         IssueService issueService = serviceFactory.createIssueService();
         ProjectService projectService = serviceFactory.createProjectService();
         PageOfProjectsResponseModel projects = projectService.getProjects();

--- a/src/test/java/com/synopsys/integration/jira/common/rest/IssueMetaDataServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/rest/IssueMetaDataServiceTest.java
@@ -1,22 +1,32 @@
 package com.synopsys.integration.jira.common.rest;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.jira.common.cloud.JiraCloudParameterizedTest;
+import com.synopsys.integration.jira.common.cloud.service.JiraCloudServiceFactory;
+import com.synopsys.integration.jira.common.cloud.service.JiraCloudServiceTestUtility;
+import com.synopsys.integration.jira.common.cloud.service.ProjectService;
+import com.synopsys.integration.jira.common.model.components.ProjectComponent;
 import com.synopsys.integration.jira.common.model.response.IssueCreateMetadataResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueTypeResponseModel;
 import com.synopsys.integration.jira.common.model.response.ProjectIssueCreateMetadataResponseModel;
 import com.synopsys.integration.jira.common.rest.service.IssueMetaDataService;
+import com.synopsys.integration.jira.common.rest.service.IssueTypeService;
 import com.synopsys.integration.jira.common.rest.service.JiraApiClient;
 
-public class IssueMetaDataServiceTest {
+public class IssueMetaDataServiceTest extends JiraCloudParameterizedTest {
 
     @Test
     public void issueTypeInProjectTest() throws IntegrationException {
@@ -29,6 +39,36 @@ public class IssueMetaDataServiceTest {
         assertTrue(service.doesProjectContainIssueType("TEST", "VALID_TYPE_1"));
         assertTrue(service.doesProjectContainIssueType("TEST", "VALID_TYPE_2"));
         assertFalse(service.doesProjectContainIssueType("TEST", "INVALID_TYPE"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getParameters")
+    public void testIssueFields(JiraHttpClient jiraHttpClient) throws IntegrationException {
+        JiraCloudServiceTestUtility.validateConfiguration();
+        JiraCloudServiceFactory serviceFactory = JiraCloudServiceTestUtility.createServiceFactory(jiraHttpClient);
+        IssueTypeService issueTypeService = serviceFactory.createIssueTypeService();
+        ProjectService projectService = serviceFactory.createProjectService();
+        IssueMetaDataService issueMetadataService = serviceFactory.createIssueMetadataService();
+
+        String testProject = JiraCloudServiceTestUtility.getTestProject();
+        String projectKey = projectService.getProjectsByName(testProject)
+                                .getProjects()
+                                .stream()
+                                .findFirst()
+                                .map(ProjectComponent::getKey)
+                                .orElseThrow(() -> new IntegrationException("Expected to find project"));
+
+        String issueId = issueTypeService.getAllIssueTypes()
+                             .stream()
+                             .filter(issueType -> "Task".equalsIgnoreCase(issueType.getName()))
+                             .map(IssueTypeResponseModel::getId)
+                             .findFirst()
+                             .orElseThrow(() -> new IntegrationException("Expected to find issue type task"));
+
+        IssueCreateMetadataResponseModel issueFields = issueMetadataService.getCreateMetadataProjectIssueTypeFields(projectKey, issueId);
+        assertTrue(StringUtils.isNotBlank(issueFields.getExpand()));
+        assertNotNull(issueFields.getProjects());
+        assertTrue(issueFields.getProjects().size() > 0);
     }
 
     private IssueCreateMetadataResponseModel createResponse() {

--- a/src/test/java/com/synopsys/integration/jira/common/rest/IssuePropertyServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/rest/IssuePropertyServiceTest.java
@@ -24,9 +24,9 @@ import com.synopsys.integration.jira.common.cloud.service.UserSearchService;
 import com.synopsys.integration.jira.common.model.EntityProperty;
 import com.synopsys.integration.jira.common.model.components.IssuePropertyKeyComponent;
 import com.synopsys.integration.jira.common.model.components.ProjectComponent;
+import com.synopsys.integration.jira.common.model.response.IssueCreationResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssuePropertyKeysResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssuePropertyResponseModel;
-import com.synopsys.integration.jira.common.model.response.IssueResponseModel;
 import com.synopsys.integration.jira.common.model.response.PageOfProjectsResponseModel;
 import com.synopsys.integration.jira.common.model.response.UserDetailsResponseModel;
 import com.synopsys.integration.jira.common.rest.service.IssuePropertyService;
@@ -62,7 +62,7 @@ public class IssuePropertyServiceTest extends JiraCloudParameterizedTest {
         String issueType = "bug";
         List<EntityProperty> properties = new LinkedList<>();
         IssueCreationRequestModel requestModel = new IssueCreationRequestModel(userDetails.getEmailAddress(), issueType, project.getName(), fieldsBuilder, properties);
-        IssueResponseModel createdIssue = issueService.createIssue(requestModel);
+        IssueCreationResponseModel createdIssue = issueService.createIssue(requestModel);
 
         String testPropertyKey = "test-property-key";
         String testObjectKey = "exampleKey";
@@ -104,7 +104,7 @@ public class IssuePropertyServiceTest extends JiraCloudParameterizedTest {
         String issueType = "bug";
         List<EntityProperty> properties = new LinkedList<>();
         IssueCreationRequestModel requestModel = new IssueCreationRequestModel(userDetails.getEmailAddress(), issueType, project.getName(), fieldsBuilder, properties);
-        IssueResponseModel createdIssue = issueService.createIssue(requestModel);
+        IssueCreationResponseModel createdIssue = issueService.createIssue(requestModel);
 
         String testPropertyKey = "test-property-key";
         String testObjectKey = "exampleKey";

--- a/src/test/java/com/synopsys/integration/jira/common/server/IssueSearchServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/server/IssueSearchServiceTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.exception.IntegrationException;
-import com.synopsys.integration.jira.common.model.response.IssueResponseModel;
+import com.synopsys.integration.jira.common.model.response.IssueCreationResponseModel;
 import com.synopsys.integration.jira.common.rest.JiraHttpClient;
 import com.synopsys.integration.jira.common.rest.service.IssuePropertyService;
 import com.synopsys.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
@@ -34,7 +34,7 @@ public class IssueSearchServiceTest extends JiraServerParameterizedTest {
         String projectName = JiraServerServiceTestUtility.getTestProject();
         String searchTerm = "my_extra_special_word";
         String description = "Example description containing a special word to search on: " + searchTerm;
-        IssueResponseModel issue = createIssue(issueService, projectName, description);
+        IssueCreationResponseModel issue = createIssue(issueService, projectName, description);
 
         try {
             IssueSearchService issueSearchService = serviceFactory.createIssueSearchService();
@@ -66,7 +66,7 @@ public class IssueSearchServiceTest extends JiraServerParameterizedTest {
         IssuePropertyService issuePropertyService = serviceFactory.createIssuePropertyService();
 
         String projectName = JiraServerServiceTestUtility.getTestProject();
-        IssueResponseModel issue = createIssue(issueService, projectName, "Test description");
+        IssueCreationResponseModel issue = createIssue(issueService, projectName, "Test description");
 
         Gson gson = new Gson();
         TestPropertyClass testPropertyClass = new TestPropertyClass("innerValue");
@@ -92,7 +92,7 @@ public class IssueSearchServiceTest extends JiraServerParameterizedTest {
         }
     }
 
-    private IssueResponseModel createIssue(IssueService issueService, String projectName, String description) throws IntegrationException {
+    private IssueCreationResponseModel createIssue(IssueService issueService, String projectName, String description) throws IntegrationException {
         String reporter = "admin";
         String issueTypeName = "Task";
 

--- a/src/test/java/com/synopsys/integration/jira/common/server/IssueServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/server/IssueServiceTest.java
@@ -1,19 +1,26 @@
 package com.synopsys.integration.jira.common.server;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.UUID;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.jira.common.model.components.ProjectComponent;
 import com.synopsys.integration.jira.common.model.response.IssueResponseModel;
+import com.synopsys.integration.jira.common.model.response.IssueTypeResponseModel;
 import com.synopsys.integration.jira.common.rest.JiraHttpClient;
+import com.synopsys.integration.jira.common.rest.model.JiraResponse;
+import com.synopsys.integration.jira.common.rest.service.IssueTypeService;
 import com.synopsys.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
 import com.synopsys.integration.jira.common.server.model.IssueCreationRequestModel;
 import com.synopsys.integration.jira.common.server.service.IssueService;
 import com.synopsys.integration.jira.common.server.service.JiraServerServiceFactory;
+import com.synopsys.integration.jira.common.server.service.ProjectService;
 
 public class IssueServiceTest extends JiraServerParameterizedTest {
     @ParameterizedTest
@@ -35,6 +42,33 @@ public class IssueServiceTest extends JiraServerParameterizedTest {
         IssueCreationRequestModel issueCreationRequestModel = new IssueCreationRequestModel(reporter, issueTypeName, projectName, issueRequestModelFieldsBuilder);
         IssueResponseModel issue = issueService.createIssue(issueCreationRequestModel);
         assertNotNull(issue, "Expected an issue to be created.");
+    }
+
+    @ParameterizedTest
+    @MethodSource("getParameters")
+    public void getIssueFieldsTest(JiraHttpClient jiraHttpClient) throws IntegrationException {
+        JiraServerServiceTestUtility.validateConfiguration();
+        JiraServerServiceFactory serviceFactory = JiraServerServiceTestUtility.createServiceFactory(jiraHttpClient);
+        IssueService issueService = serviceFactory.createIssueService();
+        IssueTypeService issueTypeService = serviceFactory.createIssueTypeService();
+        ProjectService projectService = serviceFactory.createProjectService();
+
+        String testProject = JiraServerServiceTestUtility.getTestProject();
+        String projectKey = projectService.getProjectsByName(testProject)
+                                .stream()
+                                .findFirst()
+                                .map(ProjectComponent::getKey)
+                                .orElseThrow(() -> new IntegrationException("Expected to find project"));
+
+        String issueId = issueTypeService.getAllIssueTypes()
+                             .stream()
+                             .filter(issueType -> "Task".equalsIgnoreCase(issueType.getName()))
+                             .map(IssueTypeResponseModel::getId)
+                             .findFirst()
+                             .orElseThrow(() -> new IntegrationException("Expected to find issue type task"));
+
+        JiraResponse issueFields = issueService.getIssueFields(projectKey, issueId);
+        assertTrue(StringUtils.isNotBlank(issueFields.getContent()));
     }
 
 }

--- a/src/test/java/com/synopsys/integration/jira/common/server/IssueServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/server/IssueServiceTest.java
@@ -15,18 +15,13 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.jira.common.model.components.IssueFieldsComponent;
-import com.synopsys.integration.jira.common.model.components.ProjectComponent;
 import com.synopsys.integration.jira.common.model.response.IssueCreationResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueResponseModel;
-import com.synopsys.integration.jira.common.model.response.IssueTypeResponseModel;
 import com.synopsys.integration.jira.common.rest.JiraHttpClient;
-import com.synopsys.integration.jira.common.rest.model.JiraResponse;
-import com.synopsys.integration.jira.common.rest.service.IssueTypeService;
 import com.synopsys.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
 import com.synopsys.integration.jira.common.server.model.IssueCreationRequestModel;
 import com.synopsys.integration.jira.common.server.service.IssueService;
 import com.synopsys.integration.jira.common.server.service.JiraServerServiceFactory;
-import com.synopsys.integration.jira.common.server.service.ProjectService;
 
 public class IssueServiceTest extends JiraServerParameterizedTest {
     @ParameterizedTest
@@ -48,33 +43,6 @@ public class IssueServiceTest extends JiraServerParameterizedTest {
         IssueCreationRequestModel issueCreationRequestModel = new IssueCreationRequestModel(reporter, issueTypeName, projectName, issueRequestModelFieldsBuilder);
         IssueCreationResponseModel issue = issueService.createIssue(issueCreationRequestModel);
         assertNotNull(issue, "Expected an issue to be created.");
-    }
-
-    @ParameterizedTest
-    @MethodSource("getParameters")
-    public void getIssueFieldsTest(JiraHttpClient jiraHttpClient) throws IntegrationException {
-        JiraServerServiceTestUtility.validateConfiguration();
-        JiraServerServiceFactory serviceFactory = JiraServerServiceTestUtility.createServiceFactory(jiraHttpClient);
-        IssueService issueService = serviceFactory.createIssueService();
-        IssueTypeService issueTypeService = serviceFactory.createIssueTypeService();
-        ProjectService projectService = serviceFactory.createProjectService();
-
-        String testProject = JiraServerServiceTestUtility.getTestProject();
-        String projectKey = projectService.getProjectsByName(testProject)
-                                .stream()
-                                .findFirst()
-                                .map(ProjectComponent::getKey)
-                                .orElseThrow(() -> new IntegrationException("Expected to find project"));
-
-        String issueId = issueTypeService.getAllIssueTypes()
-                             .stream()
-                             .filter(issueType -> "Task".equalsIgnoreCase(issueType.getName()))
-                             .map(IssueTypeResponseModel::getId)
-                             .findFirst()
-                             .orElseThrow(() -> new IntegrationException("Expected to find issue type task"));
-
-        JiraResponse issueFields = issueService.getIssueFields(projectKey, issueId);
-        assertTrue(StringUtils.isNotBlank(issueFields.getContent()));
     }
 
     @ParameterizedTest

--- a/src/test/java/com/synopsys/integration/jira/common/server/IssueServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/server/IssueServiceTest.java
@@ -16,6 +16,7 @@ import com.google.gson.JsonPrimitive;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.jira.common.model.components.IssueFieldsComponent;
 import com.synopsys.integration.jira.common.model.components.ProjectComponent;
+import com.synopsys.integration.jira.common.model.response.IssueCreationResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueTypeResponseModel;
 import com.synopsys.integration.jira.common.rest.JiraHttpClient;
@@ -45,7 +46,7 @@ public class IssueServiceTest extends JiraServerParameterizedTest {
         issueRequestModelFieldsBuilder.setDescription("Test description");
 
         IssueCreationRequestModel issueCreationRequestModel = new IssueCreationRequestModel(reporter, issueTypeName, projectName, issueRequestModelFieldsBuilder);
-        IssueResponseModel issue = issueService.createIssue(issueCreationRequestModel);
+        IssueCreationResponseModel issue = issueService.createIssue(issueCreationRequestModel);
         assertNotNull(issue, "Expected an issue to be created.");
     }
 
@@ -97,7 +98,7 @@ public class IssueServiceTest extends JiraServerParameterizedTest {
         issueRequestModelFieldsBuilder.setField(key, value);
 
         IssueCreationRequestModel issueCreationRequestModel = new IssueCreationRequestModel(reporter, issueTypeName, projectName, issueRequestModelFieldsBuilder);
-        IssueResponseModel issueCreationResponse = issueService.createIssue(issueCreationRequestModel);
+        IssueCreationResponseModel issueCreationResponse = issueService.createIssue(issueCreationRequestModel);
 
         assertNotNull(issueCreationResponse);
         assertTrue(StringUtils.isNotBlank(issueCreationResponse.getKey()));

--- a/src/test/java/com/synopsys/integration/jira/common/server/ServerIssuePropertyServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/server/ServerIssuePropertyServiceTest.java
@@ -11,9 +11,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.jira.common.model.response.IssueCreationResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssuePropertyKeysResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssuePropertyResponseModel;
-import com.synopsys.integration.jira.common.model.response.IssueResponseModel;
 import com.synopsys.integration.jira.common.rest.JiraHttpClient;
 import com.synopsys.integration.jira.common.rest.service.IssuePropertyService;
 import com.synopsys.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
@@ -34,7 +34,7 @@ public class ServerIssuePropertyServiceTest extends JiraServerParameterizedTest 
         Gson gson = new Gson();
 
         String projectName = JiraServerServiceTestUtility.getTestProject();
-        IssueResponseModel issue = createIssue(issueService, projectName);
+        IssueCreationResponseModel issue = createIssue(issueService, projectName);
 
         String propertyKey = "examplePropertyKey";
         try {
@@ -60,7 +60,7 @@ public class ServerIssuePropertyServiceTest extends JiraServerParameterizedTest 
         }
     }
 
-    private IssueResponseModel createIssue(IssueService issueService, String projectName) throws IntegrationException {
+    private IssueCreationResponseModel createIssue(IssueService issueService, String projectName) throws IntegrationException {
         String reporter = "admin";
         String issueTypeName = "Task";
 

--- a/src/test/java/com/synopsys/integration/jira/common/server/VersionServiceTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/server/VersionServiceTest.java
@@ -1,0 +1,53 @@
+package com.synopsys.integration.jira.common.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.UUID;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.jira.common.model.components.ProjectComponent;
+import com.synopsys.integration.jira.common.rest.JiraHttpClient;
+import com.synopsys.integration.jira.common.server.model.VersionResponseModel;
+import com.synopsys.integration.jira.common.server.service.JiraServerServiceFactory;
+import com.synopsys.integration.jira.common.server.service.ProjectService;
+import com.synopsys.integration.jira.common.server.service.VersionService;
+import com.synopsys.integration.rest.exception.IntegrationRestException;
+
+public class VersionServiceTest extends JiraServerParameterizedTest {
+
+    @ParameterizedTest
+    @MethodSource("getParameters")
+    public void findUsersByUsernameTest(JiraHttpClient jiraHttpClient) throws IntegrationException {
+        JiraServerServiceTestUtility.validateConfiguration();
+
+        JiraServerServiceFactory serviceFactory = JiraServerServiceTestUtility.createServiceFactory(jiraHttpClient);
+        VersionService versionService = serviceFactory.createVersionService();
+
+        String testProject = JiraServerServiceTestUtility.getTestProject();
+        ProjectService projectService = serviceFactory.createProjectService();
+        ProjectComponent projectComponent = projectService.getProjectsByName(testProject)
+                                                .stream()
+                                                .findFirst()
+                                                .orElseThrow(() -> new IntegrationException("Expected to find project"));
+        String generatedVersion = UUID.randomUUID().toString();
+        VersionResponseModel version = versionService.createVersion(generatedVersion, projectComponent.getId());
+        assertEquals(generatedVersion, version.getName());
+
+        VersionResponseModel createdVersion = versionService.getVersion(version.getId());
+        assertEquals(generatedVersion, createdVersion.getName());
+
+        versionService.deleteVersion(version.getId());
+
+        try {
+            versionService.getVersion(version.getId());
+            fail("Should have thrown a 404 error");
+        } catch (IntegrationRestException e) {
+            assertEquals(404, e.getHttpStatusCode());
+        }
+
+    }
+}


### PR DESCRIPTION
This ended up larger than I anticipated. But that's mostly due to renaming.

Created a server project version API. Added some tests to verify it works properly
Added the ability to set custom fields when creating a new issue
Made some models more accurate to the data that is actually being returned.
Added a new createmeta endpoint method for retrieving all fields for a specific project issue type. Added tests to verify this works.