### PR TITLE
Added method for retrieving typed fields in IssueTypeResponseModel

### DIFF
--- a/src/main/java/com/synopsys/integration/jira/common/model/response/IssueTypeResponseModel.java
+++ b/src/main/java/com/synopsys/integration/jira/common/model/response/IssueTypeResponseModel.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.synopsys.integration.jira.common.model.JiraResponseModel;
+import com.synopsys.integration.rest.component.IntRestComponent;
 
 public class IssueTypeResponseModel extends JiraResponseModel {
     private String self;
@@ -97,7 +98,7 @@ public class IssueTypeResponseModel extends JiraResponseModel {
     public Map<String, IssueCreatemetaFieldResponseModel> getTypedFields(Gson gson) {
         return getFields().entrySet()
                    .stream()
-                   .filter(entry -> entry.getKey() != "json")
+                   .filter(entry -> entry.getKey() != IntRestComponent.FIELD_NAME_JSON)
                    .collect(Collectors.toMap(Map.Entry::getKey, entry -> extractValues(gson, entry.getValue())));
     }
 

--- a/src/main/java/com/synopsys/integration/jira/common/model/response/IssueTypeResponseModel.java
+++ b/src/main/java/com/synopsys/integration/jira/common/model/response/IssueTypeResponseModel.java
@@ -23,7 +23,9 @@
 package com.synopsys.integration.jira.common.model.response;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.synopsys.integration.jira.common.model.JiraResponseModel;
 
@@ -90,5 +92,16 @@ public class IssueTypeResponseModel extends JiraResponseModel {
 
     public Map<String, JsonElement> getFields() {
         return fields;
+    }
+
+    public Map<String, IssueCreatemetaFieldResponseModel> getTypedFields(Gson gson) {
+        return getFields().entrySet()
+                   .stream()
+                   .filter(entry -> entry.getKey() != "json")
+                   .collect(Collectors.toMap(Map.Entry::getKey, entry -> extractValues(gson, entry.getValue())));
+    }
+
+    private IssueCreatemetaFieldResponseModel extractValues(Gson gson, JsonElement jsonElement) {
+        return gson.fromJson(jsonElement, IssueCreatemetaFieldResponseModel.class);
     }
 }

--- a/src/test/java/com/synopsys/integration/jira/common/rest/IssueMetaDataServiceTestIT.java
+++ b/src/test/java/com/synopsys/integration/jira/common/rest/IssueMetaDataServiceTestIT.java
@@ -3,10 +3,14 @@ package com.synopsys.integration.jira.common.rest;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import com.google.gson.Gson;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.jira.common.cloud.JiraCloudParameterizedTestIT;
 import com.synopsys.integration.jira.common.cloud.service.JiraCloudServiceFactory;
@@ -14,7 +18,9 @@ import com.synopsys.integration.jira.common.cloud.service.JiraCloudServiceTestUt
 import com.synopsys.integration.jira.common.cloud.service.ProjectService;
 import com.synopsys.integration.jira.common.model.components.ProjectComponent;
 import com.synopsys.integration.jira.common.model.response.IssueCreateMetadataResponseModel;
+import com.synopsys.integration.jira.common.model.response.IssueCreatemetaFieldResponseModel;
 import com.synopsys.integration.jira.common.model.response.IssueTypeResponseModel;
+import com.synopsys.integration.jira.common.model.response.ProjectIssueCreateMetadataResponseModel;
 import com.synopsys.integration.jira.common.rest.service.IssueMetaDataService;
 import com.synopsys.integration.jira.common.rest.service.IssueTypeService;
 
@@ -47,5 +53,45 @@ public class IssueMetaDataServiceTestIT extends JiraCloudParameterizedTestIT {
         assertTrue(StringUtils.isNotBlank(issueFields.getExpand()));
         assertNotNull(issueFields.getProjects());
         assertTrue(issueFields.getProjects().size() > 0);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getParameters")
+    public void testIssueFieldsExtraction(JiraHttpClient jiraHttpClient) throws IntegrationException {
+        JiraCloudServiceTestUtility.validateConfiguration();
+        JiraCloudServiceFactory serviceFactory = JiraCloudServiceTestUtility.createServiceFactory(jiraHttpClient);
+        IssueTypeService issueTypeService = serviceFactory.createIssueTypeService();
+        ProjectService projectService = serviceFactory.createProjectService();
+        IssueMetaDataService issueMetadataService = serviceFactory.createIssueMetadataService();
+
+        String testProject = JiraCloudServiceTestUtility.getTestProject();
+        String projectKey = projectService.getProjectsByName(testProject)
+                                .getProjects()
+                                .stream()
+                                .findFirst()
+                                .map(ProjectComponent::getKey)
+                                .orElseThrow(() -> new IntegrationException("Expected to find project"));
+
+        String issueId = issueTypeService.getAllIssueTypes()
+                             .stream()
+                             .filter(issueType -> "Task".equalsIgnoreCase(issueType.getName()))
+                             .map(IssueTypeResponseModel::getId)
+                             .findFirst()
+                             .orElseThrow(() -> new IntegrationException("Expected to find issue type task"));
+
+        IssueCreateMetadataResponseModel issueFields = issueMetadataService.getCreateMetadataProjectIssueTypeFields(projectKey, issueId);
+        assertTrue(StringUtils.isNotBlank(issueFields.getExpand()));
+        assertNotNull(issueFields.getProjects());
+
+        List<ProjectIssueCreateMetadataResponseModel> projects = issueFields.getProjects();
+        assertTrue(projects.size() > 0);
+
+        ProjectIssueCreateMetadataResponseModel projectIssueCreateMetadataResponseModel = projects.get(0);
+        IssueTypeResponseModel issueTypeResponseModel = projectIssueCreateMetadataResponseModel.getIssueTypes().get(0);
+        Map<String, IssueCreatemetaFieldResponseModel> fields = issueTypeResponseModel.getTypedFields(new Gson());
+
+        assertNotNull(fields);
+        assertTrue(fields.entrySet().size() > 0);
+        assertTrue(fields.keySet().contains("summary"));
     }
 }


### PR DESCRIPTION
The reason I need to add this method is because of the IntRestComponent. It adds the Json field which is parsed into the map causing an error when gson initially creates this object. The method goes back through the array and removes the json field then parses.

I'm open to alternatives as I would prefer the map gets parsed properly from the beginning. I do not like this approach.