### PR TITLE
Open access to overloaded createIssue methods in IssueService

### DIFF
--- a/src/main/java/com/synopsys/integration/jira/common/cloud/service/IssueService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/cloud/service/IssueService.java
@@ -98,7 +98,7 @@ public class IssueService {
                    .orElseThrow(() -> new JiraPreconditionNotMetException(String.format("Reporter user with email not found; email: %s", reporterEmail)));
     }
 
-    private IssueCreationResponseModel createIssue(IssueRequestModel requestModel) throws IntegrationException {
+    public IssueCreationResponseModel createIssue(IssueRequestModel requestModel) throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl(createApiUri());
         return jiraCloudService.post(requestModel, httpUrl, IssueCreationResponseModel.class);
     }

--- a/src/main/java/com/synopsys/integration/jira/common/server/service/IssueService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/service/IssueService.java
@@ -97,7 +97,7 @@ public class IssueService {
         return createIssue(issueRequestModel);
     }
 
-    private IssueCreationResponseModel createIssue(IssueRequestModel requestModel) throws IntegrationException {
+    public IssueCreationResponseModel createIssue(IssueRequestModel requestModel) throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl(createApiUri());
         return jiraApiClient.post(requestModel, httpUrl, IssueCreationResponseModel.class);
     }


### PR DESCRIPTION
# Pull Request template

**Link to github issue (if applicable):**

N/A

**If nothing above, what is your reason for this pull request:**
* Particularly in "...cloud/service/IssueService.java", the only visible `createIssue` method is not very flexible. It assumes we want to create an issue by matching on issue type name and project name. If we already know the identifiers of the issue type and project we want to use, it would be best to avoid these two service calls. By opening up the `createIssue(IssueRequestModel requestModel)` method variant to be public, a caller has more flexibility on how they want to create issues.

**Changes proposed in this pull request:**

* For both `cloud` and `server` `IssueService`, change private access modified to public for createIssue method variant.
