### PR TITLE
Add new HttpClient for bearer token authentication

### DIFF
--- a/src/main/java/com/synopsys/integration/jira/common/rest/token/JiraTokenHttpClient.java
+++ b/src/main/java/com/synopsys/integration/jira/common/rest/token/JiraTokenHttpClient.java
@@ -1,0 +1,104 @@
+package com.synopsys.integration.jira.common.rest.token;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.HttpUriRequest;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.jira.common.rest.JiraHttpClient;
+import com.synopsys.integration.jira.common.rest.model.JiraRequest;
+import com.synopsys.integration.jira.common.rest.model.JiraResponse;
+import com.synopsys.integration.log.IntLogger;
+import com.synopsys.integration.rest.HttpMethod;
+import com.synopsys.integration.rest.HttpUrl;
+import com.synopsys.integration.rest.body.BodyContentConverter;
+import com.synopsys.integration.rest.body.StringBodyContent;
+import com.synopsys.integration.rest.client.AuthenticatingIntHttpClient;
+import com.synopsys.integration.rest.proxy.ProxyInfo;
+import com.synopsys.integration.rest.request.Request;
+import com.synopsys.integration.rest.response.Response;
+import com.synopsys.integration.rest.support.AuthenticationSupport;
+
+public class JiraTokenHttpClient extends AuthenticatingIntHttpClient implements JiraHttpClient {
+    private static final String AUTHORIZATION_TYPE = "Bearer";
+    private final AuthenticationSupport authenticationSupport;
+    private final String baseUrl;
+    private final String accessToken;
+
+    public JiraTokenHttpClient(
+        IntLogger logger,
+        Gson gson,
+        int timeout,
+        boolean alwaysTrustServerCertificate,
+        ProxyInfo proxyInfo,
+        String baseUrl,
+        AuthenticationSupport authenticationSupport,
+        String accessToken
+    ) {
+        super(logger, gson, timeout, alwaysTrustServerCertificate, proxyInfo);
+        this.authenticationSupport = authenticationSupport;
+        this.baseUrl = baseUrl;
+        this.accessToken = accessToken;
+    }
+
+    @Override
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    @Override
+    public JiraResponse execute(JiraRequest jiraRequest) throws IntegrationException {
+        Request request = convertToRequest(jiraRequest);
+        try (Response response = execute(request)) {
+            throwExceptionForError(response);
+            return convertToJiraResponse(jiraRequest.getMethod(), jiraRequest.getUrl(), response);
+        } catch (IOException e) {
+            throw new IntegrationException("Was unable to close response object: " + e.getCause(), e);
+        }
+    }
+
+    private Request convertToRequest(JiraRequest jiraRequest) {
+        Map<String, String> completeHeaders = new HashMap<>(jiraRequest.getHeaders());
+        if (!completeHeaders.containsKey(HttpHeaders.ACCEPT)) {
+            completeHeaders.put(HttpHeaders.ACCEPT, jiraRequest.getAcceptMimeType());
+        }
+
+        Request.Builder builder = new Request.Builder()
+            .url(jiraRequest.getUrl())
+            .method(jiraRequest.getMethod())
+            .headers(completeHeaders)
+            .queryParameters(jiraRequest.getQueryParameters());
+        if (StringUtils.isNotBlank(jiraRequest.getBodyContent())) {
+            builder
+                .bodyContent(new StringBodyContent(jiraRequest.getBodyContent(), BodyContentConverter.DEFAULT))
+                .bodyEncoding(jiraRequest.getBodyEncoding());
+        }
+        return builder.build();
+    }
+
+    private JiraResponse convertToJiraResponse(HttpMethod httpMethod, HttpUrl httpUrl, Response response) throws IntegrationException {
+        return new JiraResponse(httpMethod, httpUrl, response.getStatusCode(), response.getStatusMessage(), response.getContentString(), response.getHeaders());
+    }
+
+    @Override
+    public boolean isAlreadyAuthenticated(HttpUriRequest request) {
+        return authenticationSupport.isTokenAlreadyAuthenticated(request);
+    }
+
+    @Override
+    public Response attemptAuthentication() {
+        // Bearer Authorization type is added when creating the request, we can skip this step.
+        return null;
+    }
+
+    @Override
+    protected void completeAuthenticationRequest(HttpUriRequest request, Response response) {
+        String headerValues = String.format("%s %s", AUTHORIZATION_TYPE, accessToken);
+        authenticationSupport.addAuthenticationHeader(this, request, AuthenticationSupport.AUTHORIZATION_HEADER, headerValues);
+    }
+}

--- a/src/test/java/com/synopsys/integration/jira/common/rest/token/JiraTokenHttpClientTestIT.java
+++ b/src/test/java/com/synopsys/integration/jira/common/rest/token/JiraTokenHttpClientTestIT.java
@@ -1,0 +1,59 @@
+package com.synopsys.integration.jira.common.rest.token;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.jira.common.IntegrationsTestConstants;
+import com.synopsys.integration.jira.common.model.response.IssueCreationResponseModel;
+import com.synopsys.integration.jira.common.rest.JiraHttpClient;
+import com.synopsys.integration.jira.common.server.JiraServerServiceTestUtility;
+import com.synopsys.integration.jira.common.server.builder.IssueRequestModelFieldsBuilder;
+import com.synopsys.integration.jira.common.server.model.IssueCreationRequestModel;
+import com.synopsys.integration.jira.common.server.service.IssueService;
+import com.synopsys.integration.jira.common.server.service.JiraServerServiceFactory;
+import com.synopsys.integration.jira.common.test.TestProperties;
+import com.synopsys.integration.jira.common.test.TestPropertyKey;
+import com.synopsys.integration.log.LogLevel;
+import com.synopsys.integration.log.PrintStreamIntLogger;
+import com.synopsys.integration.rest.proxy.ProxyInfo;
+import com.synopsys.integration.rest.support.AuthenticationSupport;
+
+@Tag(IntegrationsTestConstants.INTEGRATION_TEST)
+class JiraTokenHttpClientTestIT {
+    private final TestProperties testProperties = TestProperties.loadTestProperties();
+    private final String projectName = testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_TEST_PROJECT_NAME);
+    private final String reporter = testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_USERNAME);
+    private final String issueTypeName = testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_ISSUE_TYPE);
+    private final String url = testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_URL);
+    private final String accessToken = testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_PERSONAL_ACCESS_TOKEN);
+    private final PrintStreamIntLogger intLogger = new PrintStreamIntLogger(System.out, LogLevel.WARN);
+    private final Gson gson = new Gson();
+    private final ProxyInfo proxyInfo = ProxyInfo.NO_PROXY_INFO;
+    private final AuthenticationSupport authenticationSupport = new AuthenticationSupport();
+
+    @Test
+    void jiraServerTokenAuthTest() throws IntegrationException {
+        JiraHttpClient jiraHttpClient = new JiraTokenHttpClient(intLogger, gson, 120, true, proxyInfo, url, authenticationSupport, accessToken);
+        testService(jiraHttpClient);
+    }
+
+    private void testService(JiraHttpClient jiraHttpClient) throws IntegrationException {
+        JiraServerServiceFactory serviceFactory = JiraServerServiceTestUtility.createServiceFactory(jiraHttpClient);
+        IssueService issueService = serviceFactory.createIssueService();
+
+        IssueRequestModelFieldsBuilder issueRequestModelFieldsBuilder = new IssueRequestModelFieldsBuilder();
+        issueRequestModelFieldsBuilder.setSummary("Created by a JUnit Test in int-jira-common: " + UUID.randomUUID().toString());
+        issueRequestModelFieldsBuilder.setDescription("Test description");
+
+        IssueCreationRequestModel issueCreationRequestModel = new IssueCreationRequestModel(reporter, issueTypeName, projectName, issueRequestModelFieldsBuilder);
+        IssueCreationResponseModel issue = issueService.createIssue(issueCreationRequestModel);
+        assertNotNull(issue, "Expected an issue to be created.");
+    }
+
+}

--- a/src/test/java/com/synopsys/integration/jira/common/test/TestPropertyKey.java
+++ b/src/test/java/com/synopsys/integration/jira/common/test/TestPropertyKey.java
@@ -9,6 +9,7 @@ public enum TestPropertyKey {
     TEST_JIRA_SERVER_RESOLVE_TRANSITION("jira.server.resolve.transition"),
     TEST_JIRA_SERVER_REOPEN_TRANSITION("jira.server.reopen.transition"),
     TEST_JIRA_SERVER_OAUTH_ACCESS_TOKEN("jira.server.oauth.access.token"),
+    TEST_JIRA_SERVER_PERSONAL_ACCESS_TOKEN("jira.server.personal.access.token"),
 
     TEST_JIRA_CLOUD_URL("jira.cloud.url"),
     TEST_JIRA_CLOUD_EMAIL("jira.cloud.email"),


### PR DESCRIPTION
This PR is to add support for bearer token authentication in Jira Server, but in the future should also be extended for use in Jira Cloud. This class is similar to JiraCredentialHttpClient and the abstract class from integration-rest in BasicAuthHttpClient. The primary differentiation is in the creation of Authorization request headers.


