### PR TITLE
IALERT-3433 jira server token config

### DIFF
--- a/src/main/java/com/synopsys/integration/jira/common/rest/token/JiraAccessTokenHttpClient.java
+++ b/src/main/java/com/synopsys/integration/jira/common/rest/token/JiraAccessTokenHttpClient.java
@@ -31,13 +31,13 @@ import com.synopsys.integration.rest.request.Request;
 import com.synopsys.integration.rest.response.Response;
 import com.synopsys.integration.rest.support.AuthenticationSupport;
 
-public class JiraTokenHttpClient extends AuthenticatingIntHttpClient implements JiraHttpClient {
+public class JiraAccessTokenHttpClient extends AuthenticatingIntHttpClient implements JiraHttpClient {
     private static final String AUTHORIZATION_TYPE = "Bearer";
     private final AuthenticationSupport authenticationSupport;
     private final String baseUrl;
     private final String accessToken;
 
-    public JiraTokenHttpClient(
+    public JiraAccessTokenHttpClient(
         IntLogger logger,
         Gson gson,
         int timeout,

--- a/src/main/java/com/synopsys/integration/jira/common/rest/token/JiraTokenHttpClient.java
+++ b/src/main/java/com/synopsys/integration/jira/common/rest/token/JiraTokenHttpClient.java
@@ -1,3 +1,10 @@
+/*
+ * int-jira-common
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.jira.common.rest.token;
 
 import java.io.IOException;

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBasicAuthRestConfig.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBasicAuthRestConfig.java
@@ -1,0 +1,53 @@
+package com.synopsys.integration.jira.common.server.configuration;
+
+import java.net.URL;
+import java.util.function.BiConsumer;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.jira.common.rest.JiraCredentialHttpClient;
+import com.synopsys.integration.jira.common.rest.JiraHttpClient;
+import com.synopsys.integration.log.IntLogger;
+import com.synopsys.integration.rest.proxy.ProxyInfo;
+import com.synopsys.integration.rest.support.AuthenticationSupport;
+
+public class JiraServerBasicAuthRestConfig extends JiraServerRestConfig {
+    private final String authUsername;
+    private final String authPassword;
+
+    protected JiraServerBasicAuthRestConfig(
+        URL jiraUrl,
+        int timeoutSeconds,
+        ProxyInfo proxyInfo,
+        boolean alwaysTrustServerCertificate,
+        Gson gson,
+        AuthenticationSupport authenticationSupport,
+        String authUsername,
+        String authPassword
+    ) {
+        super(jiraUrl, timeoutSeconds, proxyInfo, alwaysTrustServerCertificate, gson, authenticationSupport);
+        this.authUsername = authUsername;
+        this.authPassword = authPassword;
+    }
+
+    @Override
+    public JiraHttpClient createJiraHttpClient(IntLogger logger) {
+        return new JiraCredentialHttpClient(
+            logger,
+            getGson(),
+            getTimeoutSeconds(),
+            isAlwaysTrustServerCertificate(),
+            getProxyInfo(),
+            getJiraUrl().toString(),
+            getAuthenticationSupport(),
+            authUsername,
+            authPassword
+        );
+    }
+
+    @Override
+    public void populateEnvironmentVariables(BiConsumer<String, String> pairsConsumer) {
+        pairsConsumer.accept(JiraServerRestConfigBuilder.URL_KEY.getKey(), getJiraUrl().toString());
+        pairsConsumer.accept(JiraServerBasicAuthRestConfigBuilder.AUTH_USERNAME.getKey(), authUsername);
+        pairsConsumer.accept(JiraServerBasicAuthRestConfigBuilder.AUTH_PASSWORD.getKey(), authPassword);
+    }
+}

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBasicAuthRestConfig.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBasicAuthRestConfig.java
@@ -1,3 +1,10 @@
+/*
+ * int-jira-common
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.jira.common.server.configuration;
 
 import java.net.URL;

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBasicAuthRestConfigBuilder.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBasicAuthRestConfigBuilder.java
@@ -1,0 +1,79 @@
+package com.synopsys.integration.jira.common.server.configuration;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.synopsys.integration.builder.BuilderPropertyKey;
+import com.synopsys.integration.builder.BuilderStatus;
+
+public class JiraServerBasicAuthRestConfigBuilder extends JiraServerRestConfigBuilder<JiraServerBasicAuthRestConfigBuilder, JiraServerBasicAuthRestConfig> {
+    public static final BuilderPropertyKey AUTH_USERNAME = new BuilderPropertyKey("JIRA_AUTH_USERNAME");
+    public static final BuilderPropertyKey AUTH_PASSWORD = new BuilderPropertyKey("JIRA_AUTH_PASSWORD");
+
+    @Override
+    protected JiraServerBasicAuthRestConfigBuilder getThis() {
+        return this;
+    }
+
+    @Override
+    public Set<BuilderPropertyKey> getAuthenticationProperties() {
+        Set<BuilderPropertyKey> propertyKeys = new HashSet<>();
+        propertyKeys.add(AUTH_USERNAME);
+        propertyKeys.add(AUTH_PASSWORD);
+        return propertyKeys;
+    }
+
+    @Override
+    protected JiraServerBasicAuthRestConfig buildWithoutValidation() {
+        URL jiraUrl = null;
+        try {
+            jiraUrl = new URL(getUrl());
+        } catch (MalformedURLException e) {
+        }
+
+        return new JiraServerBasicAuthRestConfig(
+            jiraUrl,
+            getTimeoutInSeconds(),
+            getProxyInfo(),
+            isTrustCert(),
+            getGson(),
+            getAuthenticationSupport(),
+            getAuthUsername(),
+            getAuthPassword()
+        );
+    }
+
+    @Override
+    public void validateAuthenticationProperties(BuilderStatus builderStatus) {
+        if (StringUtils.isBlank(getAuthUsername())) {
+            builderStatus.addErrorMessage("The Jira server user name must be specified.");
+        }
+
+        if (StringUtils.isBlank(getAuthPassword())) {
+            builderStatus.addErrorMessage("The Jira server password must be specified.");
+        }
+    }
+
+    public String getAuthUsername() {
+        return getProperties().get(AUTH_USERNAME);
+    }
+
+    public JiraServerBasicAuthRestConfigBuilder setAuthUsername(String authUsername) {
+        setProperty(AUTH_USERNAME, authUsername);
+        return this;
+    }
+
+    public String getAuthPassword() {
+        return getProperties().get(AUTH_PASSWORD);
+    }
+
+    public JiraServerBasicAuthRestConfigBuilder setAuthPassword(String authPassword) {
+        setProperty(AUTH_PASSWORD, authPassword);
+        return this;
+    }
+
+}

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBasicAuthRestConfigBuilder.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBasicAuthRestConfigBuilder.java
@@ -1,3 +1,10 @@
+/*
+ * int-jira-common
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.jira.common.server.configuration;
 
 import java.net.MalformedURLException;

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBasicAuthRestConfigBuilder.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBasicAuthRestConfigBuilder.java
@@ -39,7 +39,7 @@ public class JiraServerBasicAuthRestConfigBuilder extends JiraServerRestConfigBu
         URL jiraUrl = null;
         try {
             jiraUrl = new URL(getUrl());
-        } catch (MalformedURLException e) {
+        } catch (MalformedURLException ignored) {
         }
 
         return new JiraServerBasicAuthRestConfig(

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfig.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfig.java
@@ -1,0 +1,48 @@
+package com.synopsys.integration.jira.common.server.configuration;
+
+import java.net.URL;
+import java.util.function.BiConsumer;
+
+import com.google.gson.Gson;
+import com.synopsys.integration.jira.common.rest.JiraHttpClient;
+import com.synopsys.integration.jira.common.rest.token.JiraTokenHttpClient;
+import com.synopsys.integration.log.IntLogger;
+import com.synopsys.integration.rest.proxy.ProxyInfo;
+import com.synopsys.integration.rest.support.AuthenticationSupport;
+
+public class JiraServerBearerAuthRestConfig extends JiraServerRestConfig {
+    private final String accessToken;
+
+    public JiraServerBearerAuthRestConfig(
+        URL jiraUrl,
+        int timeoutSeconds,
+        ProxyInfo proxyInfo,
+        boolean alwaysTrustServerCertificate,
+        Gson gson,
+        AuthenticationSupport authenticationSupport,
+        String accessToken
+    ) {
+        super(jiraUrl, timeoutSeconds, proxyInfo, alwaysTrustServerCertificate, gson, authenticationSupport);
+        this.accessToken = accessToken;
+    }
+
+    @Override
+    public JiraHttpClient createJiraHttpClient(IntLogger logger) {
+        return new JiraTokenHttpClient(
+            logger,
+            getGson(),
+            getTimeoutSeconds(),
+            isAlwaysTrustServerCertificate(),
+            getProxyInfo(),
+            getJiraUrl().toString(),
+            getAuthenticationSupport(),
+            accessToken
+        );
+    }
+
+    @Override
+    public void populateEnvironmentVariables(BiConsumer<String, String> pairsConsumer) {
+        pairsConsumer.accept(JiraServerRestConfigBuilder.URL_KEY.getKey(), getJiraUrl().toString());
+        pairsConsumer.accept(JiraServerBearerAuthRestConfigBuilder.AUTH_PERSONAL_ACCESS_TOKEN.getKey(), accessToken);
+    }
+}

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfig.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfig.java
@@ -12,7 +12,7 @@ import java.util.function.BiConsumer;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.jira.common.rest.JiraHttpClient;
-import com.synopsys.integration.jira.common.rest.token.JiraTokenHttpClient;
+import com.synopsys.integration.jira.common.rest.token.JiraAccessTokenHttpClient;
 import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.rest.proxy.ProxyInfo;
 import com.synopsys.integration.rest.support.AuthenticationSupport;
@@ -35,7 +35,7 @@ public class JiraServerBearerAuthRestConfig extends JiraServerRestConfig {
 
     @Override
     public JiraHttpClient createJiraHttpClient(IntLogger logger) {
-        return new JiraTokenHttpClient(
+        return new JiraAccessTokenHttpClient(
             logger,
             getGson(),
             getTimeoutSeconds(),

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfig.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfig.java
@@ -1,3 +1,10 @@
+/*
+ * int-jira-common
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.jira.common.server.configuration;
 
 import java.net.URL;

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfigBuilder.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfigBuilder.java
@@ -44,7 +44,7 @@ public class JiraServerBearerAuthRestConfigBuilder extends JiraServerRestConfigB
         URL jiraUrl = null;
         try {
             jiraUrl = new URL(getUrl());
-        } catch (MalformedURLException e) {
+        } catch (MalformedURLException ignored) {
         }
 
         return new JiraServerBearerAuthRestConfig(

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfigBuilder.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfigBuilder.java
@@ -1,0 +1,62 @@
+package com.synopsys.integration.jira.common.server.configuration;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.synopsys.integration.builder.BuilderPropertyKey;
+import com.synopsys.integration.builder.BuilderStatus;
+
+public class JiraServerBearerAuthRestConfigBuilder extends JiraServerRestConfigBuilder<JiraServerBearerAuthRestConfigBuilder, JiraServerBearerAuthRestConfig> {
+    public static final BuilderPropertyKey AUTH_PERSONAL_ACCESS_TOKEN = new BuilderPropertyKey("JIRA_AUTH_PERSONAL_ACCESS_TOKEN");
+
+    @Override
+    protected JiraServerBearerAuthRestConfigBuilder getThis() {
+        return this;
+    }
+
+    @Override
+    public Set<BuilderPropertyKey> getAuthenticationProperties() {
+        Set<BuilderPropertyKey> propertyKeys = new HashSet<>();
+        propertyKeys.add(AUTH_PERSONAL_ACCESS_TOKEN);
+        return propertyKeys;
+    }
+
+    @Override
+    public void validateAuthenticationProperties(BuilderStatus builderStatus) {
+        if (StringUtils.isBlank(getAccessToken())) {
+            builderStatus.addErrorMessage("The Jira server user name must be specified.");
+        }
+    }
+
+    @Override
+    protected JiraServerBearerAuthRestConfig buildWithoutValidation() {
+        URL jiraUrl = null;
+        try {
+            jiraUrl = new URL(getUrl());
+        } catch (MalformedURLException e) {
+        }
+
+        return new JiraServerBearerAuthRestConfig(
+            jiraUrl,
+            getTimeoutInSeconds(),
+            getProxyInfo(),
+            isTrustCert(),
+            getGson(),
+            getAuthenticationSupport(),
+            getAccessToken()
+        );
+    }
+
+    public String getAccessToken() {
+        return getProperties().get(AUTH_PERSONAL_ACCESS_TOKEN);
+    }
+
+    public JiraServerBearerAuthRestConfigBuilder setAccessToken(String accessToken) {
+        setProperty(AUTH_PERSONAL_ACCESS_TOKEN, accessToken);
+        return this;
+    }
+}

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfigBuilder.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfigBuilder.java
@@ -1,3 +1,10 @@
+/*
+ * int-jira-common
+ *
+ * Copyright (c) 2023 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.jira.common.server.configuration;
 
 import java.net.MalformedURLException;

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerRestConfig.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerRestConfig.java
@@ -12,7 +12,6 @@ import java.util.function.BiConsumer;
 
 import com.google.gson.Gson;
 import com.synopsys.integration.builder.Buildable;
-import com.synopsys.integration.jira.common.rest.JiraCredentialHttpClient;
 import com.synopsys.integration.jira.common.rest.JiraHttpClient;
 import com.synopsys.integration.jira.common.server.service.JiraServerServiceFactory;
 import com.synopsys.integration.log.IntLogger;
@@ -20,44 +19,37 @@ import com.synopsys.integration.rest.proxy.ProxyInfo;
 import com.synopsys.integration.rest.support.AuthenticationSupport;
 import com.synopsys.integration.util.Stringable;
 
-public class JiraServerRestConfig extends Stringable implements Buildable {
+public abstract class JiraServerRestConfig extends Stringable implements Buildable {
     private final URL jiraUrl;
     private final int timeoutSeconds;
-    private final String authUsername;
-    private final String authPassword;
     private final ProxyInfo proxyInfo;
     private final boolean alwaysTrustServerCertificate;
     private final Gson gson;
     private final AuthenticationSupport authenticationSupport;
 
-    public JiraServerRestConfig(URL jiraUrl, int timeoutSeconds, ProxyInfo proxyInfo, boolean alwaysTrustServerCertificate, Gson gson, AuthenticationSupport authenticationSupport, String authUsername, String authPassword) {
+    protected JiraServerRestConfig(
+        URL jiraUrl,
+        int timeoutSeconds,
+        ProxyInfo proxyInfo,
+        boolean alwaysTrustServerCertificate,
+        Gson gson,
+        AuthenticationSupport authenticationSupport
+    ) {
         this.jiraUrl = jiraUrl;
         this.timeoutSeconds = timeoutSeconds;
-        this.authUsername = authUsername;
-        this.authPassword = authPassword;
         this.proxyInfo = proxyInfo;
         this.alwaysTrustServerCertificate = alwaysTrustServerCertificate;
         this.gson = gson;
         this.authenticationSupport = authenticationSupport;
     }
 
-    public static final JiraServerRestConfigBuilder newBuilder() {
-        return new JiraServerRestConfigBuilder();
-    }
-
-    public JiraHttpClient createJiraHttpClient(IntLogger logger) {
-        return new JiraCredentialHttpClient(logger, gson, timeoutSeconds, alwaysTrustServerCertificate, proxyInfo, jiraUrl.toString(), authenticationSupport, authUsername, authPassword);
-    }
+    public abstract JiraHttpClient createJiraHttpClient(IntLogger logger);
 
     public JiraServerServiceFactory createJiraServerServiceFactory(IntLogger logger) {
         return new JiraServerServiceFactory(logger, createJiraHttpClient(logger), gson);
     }
 
-    public void populateEnvironmentVariables(BiConsumer<String, String> pairsConsumer) {
-        pairsConsumer.accept(JiraServerRestConfigBuilder.URL_KEY.getKey(), jiraUrl.toString());
-        pairsConsumer.accept(JiraServerRestConfigBuilder.AUTH_USERNAME.getKey(), authUsername);
-        pairsConsumer.accept(JiraServerRestConfigBuilder.AUTH_PASSWORD.getKey(), authPassword);
-    }
+    public abstract void populateEnvironmentVariables(BiConsumer<String, String> pairsConsumer);
 
     public URL getJiraUrl() {
         return jiraUrl;
@@ -65,14 +57,6 @@ public class JiraServerRestConfig extends Stringable implements Buildable {
 
     public int getTimeoutSeconds() {
         return timeoutSeconds;
-    }
-
-    public String getAuthUsername() {
-        return authUsername;
-    }
-
-    public String getAuthPassword() {
-        return authPassword;
     }
 
     public ProxyInfo getProxyInfo() {

--- a/src/test/java/com/synopsys/integration/jira/common/rest/oauth1a/AuthenticateOAuthTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/rest/oauth1a/AuthenticateOAuthTest.java
@@ -48,7 +48,10 @@ public class AuthenticateOAuthTest {
         JiraOAuthServiceFactory jiraOAuthServiceFactory = new JiraOAuthServiceFactory();
         JiraOAuthService jiraOAuthService = jiraOAuthServiceFactory.fromJiraServerUrl(currentOAuthCredentials.getBaseUrl());
 
-        OAuthAuthorizationData oAuthAuthorizationData = jiraOAuthService.createOAuthAuthorizationData(currentOAuthCredentials.getConsumerKey(), currentOAuthCredentials.getPrivateKey());
+        OAuthAuthorizationData oAuthAuthorizationData = jiraOAuthService.createOAuthAuthorizationData(
+            currentOAuthCredentials.getConsumerKey(),
+            currentOAuthCredentials.getPrivateKey()
+        );
 
         String temporaryToken = oAuthAuthorizationData.getAuthorizationToken();
         assertTrue(StringUtils.isNotBlank(temporaryToken));

--- a/src/test/java/com/synopsys/integration/jira/common/rest/token/JiraAccessTokenHttpClientTestIT.java
+++ b/src/test/java/com/synopsys/integration/jira/common/rest/token/JiraAccessTokenHttpClientTestIT.java
@@ -25,7 +25,7 @@ import com.synopsys.integration.rest.proxy.ProxyInfo;
 import com.synopsys.integration.rest.support.AuthenticationSupport;
 
 @Tag(IntegrationsTestConstants.INTEGRATION_TEST)
-class JiraTokenHttpClientTestIT {
+class JiraAccessTokenHttpClientTestIT {
     private final TestProperties testProperties = TestProperties.loadTestProperties();
     private final String projectName = testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_TEST_PROJECT_NAME);
     private final String reporter = testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_USERNAME);
@@ -39,7 +39,7 @@ class JiraTokenHttpClientTestIT {
 
     @Test
     void jiraServerTokenAuthTest() throws IntegrationException {
-        JiraHttpClient jiraHttpClient = new JiraTokenHttpClient(intLogger, gson, 120, true, proxyInfo, url, authenticationSupport, accessToken);
+        JiraHttpClient jiraHttpClient = new JiraAccessTokenHttpClient(intLogger, gson, 120, true, proxyInfo, url, authenticationSupport, accessToken);
         testService(jiraHttpClient);
     }
 

--- a/src/test/java/com/synopsys/integration/jira/common/server/JiraServerParameterizedTestIT.java
+++ b/src/test/java/com/synopsys/integration/jira/common/server/JiraServerParameterizedTestIT.java
@@ -22,9 +22,11 @@ public abstract class JiraServerParameterizedTestIT {
 
         return Arrays.asList(
             JiraServerServiceTestUtility.createJiraCredentialClient(intLogger),
+            JiraServerServiceTestUtility.createJiraBearerCredentialClient(intLogger),
             JiraOauthTestUtility.createOAuthClient(
                 testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_URL),
                 testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_OAUTH_ACCESS_TOKEN)
-            ));
+            )
+        );
     }
 }

--- a/src/test/java/com/synopsys/integration/jira/common/server/JiraServerParameterizedTestIT.java
+++ b/src/test/java/com/synopsys/integration/jira/common/server/JiraServerParameterizedTestIT.java
@@ -22,7 +22,7 @@ public abstract class JiraServerParameterizedTestIT {
 
         return Arrays.asList(
             JiraServerServiceTestUtility.createJiraCredentialClient(intLogger),
-            JiraServerServiceTestUtility.createJiraBearerCredentialClient(intLogger),
+            JiraServerServiceTestUtility.createJiraBearerAuthClient(intLogger),
             JiraOauthTestUtility.createOAuthClient(
                 testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_URL),
                 testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_OAUTH_ACCESS_TOKEN)

--- a/src/test/java/com/synopsys/integration/jira/common/server/JiraServerServiceTestUtility.java
+++ b/src/test/java/com/synopsys/integration/jira/common/server/JiraServerServiceTestUtility.java
@@ -26,7 +26,7 @@ public final class JiraServerServiceTestUtility {
     private static final Gson gson = new Gson();
 
     private static final TestProperties testProperties = TestProperties.loadTestProperties();
-    
+
     public static void validateConfiguration() {
         String baseUrl = testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_URL);
         String username = testProperties.getProperty(TestPropertyKey.TEST_JIRA_SERVER_USERNAME);
@@ -79,7 +79,7 @@ public final class JiraServerServiceTestUtility {
         return createBasicAuthJiraServerConfig().createJiraHttpClient(logger);
     }
 
-    public static JiraHttpClient createJiraBearerCredentialClient(IntLogger logger) {
+    public static JiraHttpClient createJiraBearerAuthClient(IntLogger logger) {
         return createBearerAuthJiraServerConfig().createJiraHttpClient(logger);
     }
 


### PR DESCRIPTION
We've broken up the JiraServerRestConfig and its builder into abstract objects. These will now be two separate instances of credentials to either use Basic or Bearer authentication. 

As a result of these changes we've also updated the JiraServerParameterizedTestIT and the JiraServerServiceTestUtility to now create a the new HTTP client in addition to the old basic one. This means that each integration test extending this parameterized test will now run this additional set of tests through this client. In local testing this means that the total test time increases from about 4 minutes to 5 minutes. 