### PR TITLE
IALERT-3579 - Implement logic to use SSLContext

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ description = 'A library for using various capabilities of Jira.'
 apply plugin: 'com.synopsys.integration.library'
 
 dependencies {
-    api 'com.synopsys.integration:integration-rest:10.4.1'
+    api 'com.synopsys.integration:integration-rest:10.4.3'
     api 'com.google.oauth-client:google-oauth-client:1.34.1'
 
     testImplementation 'org.mockito:mockito-core:2.18.3'

--- a/src/main/java/com/synopsys/integration/jira/common/rest/JiraCredentialHttpClient.java
+++ b/src/main/java/com/synopsys/integration/jira/common/rest/JiraCredentialHttpClient.java
@@ -29,19 +29,36 @@ import com.synopsys.integration.rest.request.Request;
 import com.synopsys.integration.rest.response.Response;
 import com.synopsys.integration.rest.support.AuthenticationSupport;
 
+import javax.net.ssl.SSLContext;
+
 public class JiraCredentialHttpClient extends BasicAuthHttpClient implements JiraHttpClient {
     private final String baseUrl;
 
-    public static final JiraHttpClient cloud(IntLogger logger, Gson gson, int timeout, boolean alwaysTrustServerCertificate, ProxyInfo proxyInfo, String baseUrl, String authUserEmail, String apiToken) {
+    // Does not use SSLContext
+    public static JiraHttpClient cloud(IntLogger logger, Gson gson, int timeout, boolean alwaysTrustServerCertificate, ProxyInfo proxyInfo, String baseUrl, String authUserEmail, String apiToken) {
         return new JiraCredentialHttpClient(logger, gson, timeout, alwaysTrustServerCertificate, proxyInfo, baseUrl, new AuthenticationSupport(), authUserEmail, apiToken);
     }
 
-    public static final JiraHttpClient server(IntLogger logger, Gson gson, int timeout, boolean alwaysTrustServerCertificate, ProxyInfo proxyInfo, String baseUrl, String username, String password) {
+    public static JiraHttpClient server(IntLogger logger, Gson gson, int timeout, boolean alwaysTrustServerCertificate, ProxyInfo proxyInfo, String baseUrl, String username, String password) {
         return new JiraCredentialHttpClient(logger, gson, timeout, alwaysTrustServerCertificate, proxyInfo, baseUrl, new AuthenticationSupport(), username, password);
     }
 
     public JiraCredentialHttpClient(IntLogger logger, Gson gson, int timeout, boolean alwaysTrustServerCertificate, ProxyInfo proxyInfo, String baseUrl, AuthenticationSupport authenticationSupport, String username, String password) {
         super(logger, gson, timeout, alwaysTrustServerCertificate, proxyInfo, authenticationSupport, username, password);
+        this.baseUrl = baseUrl;
+    }
+
+    // Uses SSLContext
+    public static JiraHttpClient cloud(IntLogger logger, Gson gson, int timeout, ProxyInfo proxyInfo, SSLContext sslContext, String baseUrl, String authUserEmail, String apiToken) {
+        return new JiraCredentialHttpClient(logger, gson, timeout, proxyInfo, sslContext, baseUrl, new AuthenticationSupport(), authUserEmail, apiToken);
+    }
+
+    public static JiraHttpClient server(IntLogger logger, Gson gson, int timeout, ProxyInfo proxyInfo, SSLContext sslContext, String baseUrl, String username, String password) {
+        return new JiraCredentialHttpClient(logger, gson, timeout, proxyInfo, sslContext, baseUrl, new AuthenticationSupport(), username, password);
+    }
+
+    public JiraCredentialHttpClient(IntLogger logger, Gson gson, int timeout, ProxyInfo proxyInfo, SSLContext sslContext, String baseUrl, AuthenticationSupport authenticationSupport, String username, String password) {
+        super(logger, gson, timeout, proxyInfo, sslContext, authenticationSupport, username, password);
         this.baseUrl = baseUrl;
     }
 

--- a/src/main/java/com/synopsys/integration/jira/common/rest/JiraHttpClientFactory.java
+++ b/src/main/java/com/synopsys/integration/jira/common/rest/JiraHttpClientFactory.java
@@ -9,11 +9,16 @@ package com.synopsys.integration.jira.common.rest;
 
 import com.google.api.client.auth.oauth.OAuthParameters;
 import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.javanet.ConnectionFactory;
 import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.common.base.Supplier;
 import com.google.gson.Gson;
 import com.synopsys.integration.jira.common.rest.oauth1a.JiraOAuthHttpClient;
 import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.rest.proxy.ProxyInfo;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 
 public class JiraHttpClientFactory {
     public static final String JIRA_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
@@ -22,17 +27,36 @@ public class JiraHttpClientFactory {
         return new JiraOAuthHttpClient(jiraUrl, createHttpRequestFactory(oAuthParameters));
     }
 
+    public JiraHttpClient createJiraOAuthClient(String jiraUrl, OAuthParameters oAuthParameters, SSLContext sslContext) {
+        return new JiraOAuthHttpClient(jiraUrl, createHttpRequestFactory(oAuthParameters, sslContext));
+    }
+
     public JiraHttpClient createJiraCloudCredentialClient(IntLogger logger, Gson gson, int timeout, boolean alwaysTrustServerCertificate, ProxyInfo proxyInfo, String baseUrl, String authUserEmail, String apiToken) {
         return JiraCredentialHttpClient.cloud(logger, gson, timeout, alwaysTrustServerCertificate, proxyInfo, baseUrl, authUserEmail, apiToken);
+    }
+
+    public JiraHttpClient createJiraCloudCredentialClient(IntLogger logger, Gson gson, int timeout, ProxyInfo proxyInfo, SSLContext sslContext, String baseUrl, String authUserEmail, String apiToken) {
+        return JiraCredentialHttpClient.cloud(logger, gson, timeout, proxyInfo, sslContext, baseUrl, authUserEmail, apiToken);
     }
 
     public JiraHttpClient createJiraServerCredentialClient(IntLogger logger, Gson gson, int timeout, boolean alwaysTrustServerCertificate, ProxyInfo proxyInfo, String baseUrl, String username, String password) {
         return JiraCredentialHttpClient.server(logger, gson, timeout, alwaysTrustServerCertificate, proxyInfo, baseUrl, username, password);
     }
 
+    public JiraHttpClient createJiraServerCredentialClient(IntLogger logger, Gson gson, int timeout, ProxyInfo proxyInfo, SSLContext sslContext, String baseUrl, String username, String password) {
+        return JiraCredentialHttpClient.server(logger, gson, timeout, proxyInfo, sslContext, baseUrl, username, password);
+    }
+
     private HttpRequestFactory createHttpRequestFactory(OAuthParameters oAuthParameters) {
         return new NetHttpTransport().createRequestFactory(oAuthParameters);
     }
 
+    private HttpRequestFactory createHttpRequestFactory(OAuthParameters oAuthParameters, SSLContext sslContext) {
+        return new NetHttpTransport
+                .Builder()
+                .setSslSocketFactory(sslContext.getSocketFactory())
+                .build()
+                .createRequestFactory(oAuthParameters);
+    }
 }
 

--- a/src/main/java/com/synopsys/integration/jira/common/rest/token/JiraAccessTokenHttpClient.java
+++ b/src/main/java/com/synopsys/integration/jira/common/rest/token/JiraAccessTokenHttpClient.java
@@ -31,6 +31,8 @@ import com.synopsys.integration.rest.request.Request;
 import com.synopsys.integration.rest.response.Response;
 import com.synopsys.integration.rest.support.AuthenticationSupport;
 
+import javax.net.ssl.SSLContext;
+
 public class JiraAccessTokenHttpClient extends AuthenticatingIntHttpClient implements JiraHttpClient {
     private static final String AUTHORIZATION_TYPE = "Bearer";
     private final AuthenticationSupport authenticationSupport;
@@ -48,6 +50,22 @@ public class JiraAccessTokenHttpClient extends AuthenticatingIntHttpClient imple
         String accessToken
     ) {
         super(logger, gson, timeout, alwaysTrustServerCertificate, proxyInfo);
+        this.authenticationSupport = authenticationSupport;
+        this.baseUrl = baseUrl;
+        this.accessToken = accessToken;
+    }
+
+    public JiraAccessTokenHttpClient(
+            IntLogger logger,
+            Gson gson,
+            int timeout,
+            ProxyInfo proxyInfo,
+            SSLContext sslContext,
+            String baseUrl,
+            AuthenticationSupport authenticationSupport,
+            String accessToken
+    ) {
+        super(logger, gson, timeout, proxyInfo, sslContext);
         this.authenticationSupport = authenticationSupport;
         this.baseUrl = baseUrl;
         this.accessToken = accessToken;

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBasicAuthRestConfig.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBasicAuthRestConfig.java
@@ -17,6 +17,8 @@ import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.rest.proxy.ProxyInfo;
 import com.synopsys.integration.rest.support.AuthenticationSupport;
 
+import javax.net.ssl.SSLContext;
+
 public class JiraServerBasicAuthRestConfig extends JiraServerRestConfig {
     private final String authUsername;
     private final String authPassword;
@@ -36,19 +38,48 @@ public class JiraServerBasicAuthRestConfig extends JiraServerRestConfig {
         this.authPassword = authPassword;
     }
 
+    protected JiraServerBasicAuthRestConfig(
+            URL jiraUrl,
+            int timeoutSeconds,
+            ProxyInfo proxyInfo,
+            SSLContext sslContext,
+            Gson gson,
+            AuthenticationSupport authenticationSupport,
+            String authUsername,
+            String authPassword
+    ) {
+        super(jiraUrl, timeoutSeconds, proxyInfo, sslContext, gson, authenticationSupport);
+        this.authUsername = authUsername;
+        this.authPassword = authPassword;
+    }
+
     @Override
     public JiraHttpClient createJiraHttpClient(IntLogger logger) {
-        return new JiraCredentialHttpClient(
-            logger,
-            getGson(),
-            getTimeoutSeconds(),
-            isAlwaysTrustServerCertificate(),
-            getProxyInfo(),
-            getJiraUrl().toString(),
-            getAuthenticationSupport(),
-            authUsername,
-            authPassword
-        );
+        if (getSslContext().isPresent()) {
+            return new JiraCredentialHttpClient(
+                    logger,
+                    getGson(),
+                    getTimeoutSeconds(),
+                    getProxyInfo(),
+                    getSslContext().get(),
+                    getJiraUrl().toString(),
+                    getAuthenticationSupport(),
+                    authUsername,
+                    authPassword
+            );
+        } else {
+            return new JiraCredentialHttpClient(
+                    logger,
+                    getGson(),
+                    getTimeoutSeconds(),
+                    isAlwaysTrustServerCertificate(),
+                    getProxyInfo(),
+                    getJiraUrl().toString(),
+                    getAuthenticationSupport(),
+                    authUsername,
+                    authPassword
+            );
+        }
     }
 
     @Override

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBasicAuthRestConfigBuilder.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBasicAuthRestConfigBuilder.java
@@ -42,16 +42,29 @@ public class JiraServerBasicAuthRestConfigBuilder extends JiraServerRestConfigBu
         } catch (MalformedURLException ignored) {
         }
 
-        return new JiraServerBasicAuthRestConfig(
-            jiraUrl,
-            getTimeoutInSeconds(),
-            getProxyInfo(),
-            isTrustCert(),
-            getGson(),
-            getAuthenticationSupport(),
-            getAuthUsername(),
-            getAuthPassword()
-        );
+        if (getSslContext().isPresent()) {
+            return new JiraServerBasicAuthRestConfig(
+                    jiraUrl,
+                    getTimeoutInSeconds(),
+                    getProxyInfo(),
+                    getSslContext().get(),
+                    getGson(),
+                    getAuthenticationSupport(),
+                    getAuthUsername(),
+                    getAuthPassword()
+            );
+        } else {
+            return new JiraServerBasicAuthRestConfig(
+                    jiraUrl,
+                    getTimeoutInSeconds(),
+                    getProxyInfo(),
+                    isTrustCert(),
+                    getGson(),
+                    getAuthenticationSupport(),
+                    getAuthUsername(),
+                    getAuthPassword()
+            );
+        }
     }
 
     @Override
@@ -70,8 +83,7 @@ public class JiraServerBasicAuthRestConfigBuilder extends JiraServerRestConfigBu
     }
 
     public JiraServerBasicAuthRestConfigBuilder setAuthUsername(String authUsername) {
-        setProperty(AUTH_USERNAME, authUsername);
-        return this;
+        return setProperty(AUTH_USERNAME, authUsername);
     }
 
     public String getAuthPassword() {
@@ -79,8 +91,7 @@ public class JiraServerBasicAuthRestConfigBuilder extends JiraServerRestConfigBu
     }
 
     public JiraServerBasicAuthRestConfigBuilder setAuthPassword(String authPassword) {
-        setProperty(AUTH_PASSWORD, authPassword);
-        return this;
+        return setProperty(AUTH_PASSWORD, authPassword);
     }
 
 }

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfig.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfig.java
@@ -17,10 +17,12 @@ import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.rest.proxy.ProxyInfo;
 import com.synopsys.integration.rest.support.AuthenticationSupport;
 
+import javax.net.ssl.SSLContext;
+
 public class JiraServerBearerAuthRestConfig extends JiraServerRestConfig {
     private final String accessToken;
 
-    public JiraServerBearerAuthRestConfig(
+    protected JiraServerBearerAuthRestConfig(
         URL jiraUrl,
         int timeoutSeconds,
         ProxyInfo proxyInfo,
@@ -33,18 +35,45 @@ public class JiraServerBearerAuthRestConfig extends JiraServerRestConfig {
         this.accessToken = accessToken;
     }
 
+    protected JiraServerBearerAuthRestConfig(
+            URL jiraUrl,
+            int timeoutSeconds,
+            ProxyInfo proxyInfo,
+            SSLContext sslContext,
+            Gson gson,
+            AuthenticationSupport authenticationSupport,
+            String accessToken
+    ) {
+        super(jiraUrl, timeoutSeconds, proxyInfo, sslContext, gson, authenticationSupport);
+        this.accessToken = accessToken;
+    }
+
     @Override
     public JiraHttpClient createJiraHttpClient(IntLogger logger) {
-        return new JiraAccessTokenHttpClient(
-            logger,
-            getGson(),
-            getTimeoutSeconds(),
-            isAlwaysTrustServerCertificate(),
-            getProxyInfo(),
-            getJiraUrl().toString(),
-            getAuthenticationSupport(),
-            accessToken
-        );
+        if (getSslContext().isPresent()) {
+            return new JiraAccessTokenHttpClient(
+                    logger,
+                    getGson(),
+                    getTimeoutSeconds(),
+                    getProxyInfo(),
+                    getSslContext().get(),
+                    getJiraUrl().toString(),
+                    getAuthenticationSupport(),
+                    accessToken
+            );
+        } else {
+            return new JiraAccessTokenHttpClient(
+                    logger,
+                    getGson(),
+                    getTimeoutSeconds(),
+                    isAlwaysTrustServerCertificate(),
+                    getProxyInfo(),
+                    getJiraUrl().toString(),
+                    getAuthenticationSupport(),
+                    accessToken
+            );
+        }
+
     }
 
     @Override

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfigBuilder.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfigBuilder.java
@@ -47,15 +47,27 @@ public class JiraServerBearerAuthRestConfigBuilder extends JiraServerRestConfigB
         } catch (MalformedURLException ignored) {
         }
 
-        return new JiraServerBearerAuthRestConfig(
-            jiraUrl,
-            getTimeoutInSeconds(),
-            getProxyInfo(),
-            isTrustCert(),
-            getGson(),
-            getAuthenticationSupport(),
-            getAccessToken()
-        );
+        if (getSslContext().isPresent()) {
+            return new JiraServerBearerAuthRestConfig(
+                    jiraUrl,
+                    getTimeoutInSeconds(),
+                    getProxyInfo(),
+                    getSslContext().get(),
+                    getGson(),
+                    getAuthenticationSupport(),
+                    getAccessToken()
+            );
+        } else {
+            return new JiraServerBearerAuthRestConfig(
+                    jiraUrl,
+                    getTimeoutInSeconds(),
+                    getProxyInfo(),
+                    isTrustCert(),
+                    getGson(),
+                    getAuthenticationSupport(),
+                    getAccessToken()
+            );
+        }
     }
 
     public String getAccessToken() {
@@ -63,7 +75,6 @@ public class JiraServerBearerAuthRestConfigBuilder extends JiraServerRestConfigB
     }
 
     public JiraServerBearerAuthRestConfigBuilder setAccessToken(String accessToken) {
-        setProperty(AUTH_PERSONAL_ACCESS_TOKEN, accessToken);
-        return this;
+        return setProperty(AUTH_PERSONAL_ACCESS_TOKEN, accessToken);
     }
 }

--- a/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerRestConfig.java
+++ b/src/main/java/com/synopsys/integration/jira/common/server/configuration/JiraServerRestConfig.java
@@ -8,6 +8,7 @@
 package com.synopsys.integration.jira.common.server.configuration;
 
 import java.net.URL;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import com.google.gson.Gson;
@@ -19,11 +20,14 @@ import com.synopsys.integration.rest.proxy.ProxyInfo;
 import com.synopsys.integration.rest.support.AuthenticationSupport;
 import com.synopsys.integration.util.Stringable;
 
+import javax.net.ssl.SSLContext;
+
 public abstract class JiraServerRestConfig extends Stringable implements Buildable {
     private final URL jiraUrl;
     private final int timeoutSeconds;
     private final ProxyInfo proxyInfo;
     private final boolean alwaysTrustServerCertificate;
+    private final SSLContext sslContext;
     private final Gson gson;
     private final AuthenticationSupport authenticationSupport;
 
@@ -39,6 +43,24 @@ public abstract class JiraServerRestConfig extends Stringable implements Buildab
         this.timeoutSeconds = timeoutSeconds;
         this.proxyInfo = proxyInfo;
         this.alwaysTrustServerCertificate = alwaysTrustServerCertificate;
+        this.sslContext = null;
+        this.gson = gson;
+        this.authenticationSupport = authenticationSupport;
+    }
+
+    protected JiraServerRestConfig(
+            URL jiraUrl,
+            int timeoutSeconds,
+            ProxyInfo proxyInfo,
+            SSLContext sslContext,
+            Gson gson,
+            AuthenticationSupport authenticationSupport
+    ) {
+        this.jiraUrl = jiraUrl;
+        this.timeoutSeconds = timeoutSeconds;
+        this.proxyInfo = proxyInfo;
+        this.alwaysTrustServerCertificate = false;
+        this.sslContext = sslContext;
         this.gson = gson;
         this.authenticationSupport = authenticationSupport;
     }
@@ -65,6 +87,10 @@ public abstract class JiraServerRestConfig extends Stringable implements Buildab
 
     public boolean isAlwaysTrustServerCertificate() {
         return alwaysTrustServerCertificate;
+    }
+
+    public Optional<SSLContext> getSslContext() {
+        return Optional.ofNullable(sslContext);
     }
 
     public Gson getGson() {

--- a/src/test/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBasicAuthRestConfigBuilderTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBasicAuthRestConfigBuilderTest.java
@@ -1,0 +1,45 @@
+package com.synopsys.integration.jira.common.server.configuration;
+
+import com.synopsys.integration.jira.common.rest.JiraCredentialHttpClient;
+import com.synopsys.integration.jira.common.rest.JiraHttpClient;
+import com.synopsys.integration.jira.common.rest.token.JiraAccessTokenHttpClient;
+import com.synopsys.integration.log.LogLevel;
+import com.synopsys.integration.log.PrintStreamIntLogger;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+import java.security.NoSuchAlgorithmException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class JiraServerBasicAuthRestConfigBuilderTest {
+
+    @Test
+    public void testUsingSSLContext() {
+        JiraServerBasicAuthRestConfigBuilder jiraServerBasicAuthRestConfigBuilder = createValidConfigBuilder();
+        assertFalse(jiraServerBasicAuthRestConfigBuilder.getSslContext().isPresent());
+
+        JiraServerBasicAuthRestConfig jiraServerBasicAuthRestConfig = jiraServerBasicAuthRestConfigBuilder.build();
+        assertFalse(jiraServerBasicAuthRestConfig.getSslContext().isPresent());
+
+        SSLContext sslContext = assertDoesNotThrow(SSLContext::getDefault);
+        jiraServerBasicAuthRestConfigBuilder.setSslContext(sslContext);
+        assertTrue(jiraServerBasicAuthRestConfigBuilder.getSslContext().isPresent());
+        jiraServerBasicAuthRestConfig = jiraServerBasicAuthRestConfigBuilder.build();
+        assertTrue(jiraServerBasicAuthRestConfig.getSslContext().isPresent());
+
+        PrintStreamIntLogger intLogger = new PrintStreamIntLogger(System.out, LogLevel.WARN);
+        JiraHttpClient jiraHttpClient = jiraServerBasicAuthRestConfig.createJiraHttpClient(intLogger);
+        assertTrue(jiraHttpClient instanceof JiraCredentialHttpClient);
+    }
+
+    private JiraServerBasicAuthRestConfigBuilder createValidConfigBuilder() {
+        return new JiraServerBasicAuthRestConfigBuilder()
+                .setUrl("http://www.google.com/fake_but_valid_not_blank_url")
+                .setAuthUsername("username")
+                .setAuthPassword("password");
+    }
+}

--- a/src/test/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfigBuilderTest.java
+++ b/src/test/java/com/synopsys/integration/jira/common/server/configuration/JiraServerBearerAuthRestConfigBuilderTest.java
@@ -1,0 +1,43 @@
+package com.synopsys.integration.jira.common.server.configuration;
+
+import com.synopsys.integration.jira.common.rest.JiraHttpClient;
+import com.synopsys.integration.jira.common.rest.token.JiraAccessTokenHttpClient;
+import com.synopsys.integration.log.LogLevel;
+import com.synopsys.integration.log.PrintStreamIntLogger;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+import java.security.NoSuchAlgorithmException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class JiraServerBearerAuthRestConfigBuilderTest {
+
+    @Test
+    public void testUsingSSLContext() {
+        JiraServerBearerAuthRestConfigBuilder jiraServerBearerAuthRestConfigBuilder = createValidConfigBuilder();
+        assertFalse(jiraServerBearerAuthRestConfigBuilder.getSslContext().isPresent());
+
+        JiraServerBearerAuthRestConfig jiraServerBearerAuthRestConfig = jiraServerBearerAuthRestConfigBuilder.build();
+        assertFalse(jiraServerBearerAuthRestConfig.getSslContext().isPresent());
+
+        SSLContext sslContext = assertDoesNotThrow(SSLContext::getDefault);
+        jiraServerBearerAuthRestConfigBuilder.setSslContext(sslContext);
+        assertTrue(jiraServerBearerAuthRestConfigBuilder.getSslContext().isPresent());
+        jiraServerBearerAuthRestConfig = jiraServerBearerAuthRestConfigBuilder.build();
+        assertTrue(jiraServerBearerAuthRestConfig.getSslContext().isPresent());
+
+        PrintStreamIntLogger intLogger = new PrintStreamIntLogger(System.out, LogLevel.WARN);
+        JiraHttpClient jiraHttpClient = jiraServerBearerAuthRestConfig.createJiraHttpClient(intLogger);
+        assertTrue(jiraHttpClient instanceof JiraAccessTokenHttpClient);
+    }
+
+    private JiraServerBearerAuthRestConfigBuilder createValidConfigBuilder() {
+        return new JiraServerBearerAuthRestConfigBuilder()
+                .setUrl("http://www.google.com/fake_but_valid_not_blank_url")
+                .setAccessToken("access_token");
+    }
+}


### PR DESCRIPTION
* Upgrade to new release of integration-rest (not yet released, but expected)
* Implement constructors to be able to use SSLContext 
* Add logic in builders to return based on presence of SSLContext
* Change to protected for config classes that are intended to be instantiated via builder
* Test coverage for using new SSLContext logic