### PR TITLE
Modify PluginManagerServiceServerTestIT to test basic auth only

### DIFF
--- a/src/main/java/com/synopsys/integration/jira/common/rest/service/PluginManagerService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/rest/service/PluginManagerService.java
@@ -29,9 +29,6 @@ public class PluginManagerService {
 
     public static final String API_PATH = "/rest/plugins/1.0/";
 
-    private static final String QUERY_KEY_OS_AUTH_TYPE = "os_authType";
-    private static final String QUERY_VALUE_OS_AUTH_TYPE = "basic";
-
     private static final String MEDIA_TYPE_PREFIX = "application/vnd.atl.plugins";
     private static final String MEDIA_TYPE_SUFFIX = "+json";
     private static final String MEDIA_TYPE_DEFAULT = "application/json";
@@ -54,7 +51,6 @@ public class PluginManagerService {
     public Optional<PluginResponseModel> getInstalledApp(String appKey) throws IntegrationException {
         HttpUrl apiUri = new HttpUrl(createBaseRequestUrl() + appKey + "-key");
         JiraRequest.Builder requestBuilder = new JiraRequest.Builder(apiUri);
-        requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_PLUGIN);
 
@@ -72,7 +68,6 @@ public class PluginManagerService {
     public boolean isAppInstalled(String appKey) throws IntegrationException {
         HttpUrl apiUri = new HttpUrl(createBaseRequestUrl() + appKey + "-key");
         JiraRequest.Builder requestBuilder = new JiraRequest.Builder(apiUri);
-        requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_PLUGIN);
 
@@ -91,7 +86,6 @@ public class PluginManagerService {
     public InstalledAppsResponseModel getInstalledApps() throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl(createBaseRequestUrl());
         JiraRequest.Builder requestBuilder = new JiraRequest.Builder(httpUrl);
-        requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_INSTALLED);
 
@@ -131,7 +125,6 @@ public class PluginManagerService {
     public String retrievePluginToken() throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl(createBaseRequestUrl());
         JiraRequest.Builder requestBuilder = new JiraRequest.Builder(httpUrl);
-        requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_INSTALLED);
         JiraRequest request = requestBuilder.build();

--- a/src/main/java/com/synopsys/integration/jira/common/rest/service/PluginManagerService.java
+++ b/src/main/java/com/synopsys/integration/jira/common/rest/service/PluginManagerService.java
@@ -29,6 +29,9 @@ public class PluginManagerService {
 
     public static final String API_PATH = "/rest/plugins/1.0/";
 
+    private static final String QUERY_KEY_OS_AUTH_TYPE = "os_authType";
+    private static final String QUERY_VALUE_OS_AUTH_TYPE = "basic";
+
     private static final String MEDIA_TYPE_PREFIX = "application/vnd.atl.plugins";
     private static final String MEDIA_TYPE_SUFFIX = "+json";
     private static final String MEDIA_TYPE_DEFAULT = "application/json";
@@ -51,6 +54,7 @@ public class PluginManagerService {
     public Optional<PluginResponseModel> getInstalledApp(String appKey) throws IntegrationException {
         HttpUrl apiUri = new HttpUrl(createBaseRequestUrl() + appKey + "-key");
         JiraRequest.Builder requestBuilder = new JiraRequest.Builder(apiUri);
+        requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_PLUGIN);
 
@@ -68,6 +72,7 @@ public class PluginManagerService {
     public boolean isAppInstalled(String appKey) throws IntegrationException {
         HttpUrl apiUri = new HttpUrl(createBaseRequestUrl() + appKey + "-key");
         JiraRequest.Builder requestBuilder = new JiraRequest.Builder(apiUri);
+        requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_PLUGIN);
 
@@ -86,6 +91,7 @@ public class PluginManagerService {
     public InstalledAppsResponseModel getInstalledApps() throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl(createBaseRequestUrl());
         JiraRequest.Builder requestBuilder = new JiraRequest.Builder(httpUrl);
+        requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_INSTALLED);
 
@@ -125,6 +131,7 @@ public class PluginManagerService {
     public String retrievePluginToken() throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl(createBaseRequestUrl());
         JiraRequest.Builder requestBuilder = new JiraRequest.Builder(httpUrl);
+        requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_INSTALLED);
         JiraRequest request = requestBuilder.build();

--- a/src/test/java/com/synopsys/integration/jira/common/rest/service/PluginManagerServiceServerTestIT.java
+++ b/src/test/java/com/synopsys/integration/jira/common/rest/service/PluginManagerServiceServerTestIT.java
@@ -2,17 +2,19 @@ package com.synopsys.integration.jira.common.rest.service;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.jira.common.IntegrationsTestConstants;
 import com.synopsys.integration.jira.common.rest.JiraHttpClient;
-import com.synopsys.integration.jira.common.server.JiraServerParameterizedTestIT;
 import com.synopsys.integration.jira.common.server.JiraServerServiceTestUtility;
 import com.synopsys.integration.jira.common.server.service.JiraServerServiceFactory;
 import com.synopsys.integration.log.LogLevel;
 import com.synopsys.integration.log.PrintStreamIntLogger;
 
-class PluginManagerServiceServerTestIT extends JiraServerParameterizedTestIT {
+@Tag(IntegrationsTestConstants.INTEGRATION_TEST)
+class PluginManagerServiceServerTestIT {
 
     @Test
     void createIssueTest() throws IntegrationException {

--- a/src/test/java/com/synopsys/integration/jira/common/rest/service/PluginManagerServiceServerTestIT.java
+++ b/src/test/java/com/synopsys/integration/jira/common/rest/service/PluginManagerServiceServerTestIT.java
@@ -2,20 +2,21 @@ package com.synopsys.integration.jira.common.rest.service;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.jira.common.rest.JiraHttpClient;
 import com.synopsys.integration.jira.common.server.JiraServerParameterizedTestIT;
 import com.synopsys.integration.jira.common.server.JiraServerServiceTestUtility;
 import com.synopsys.integration.jira.common.server.service.JiraServerServiceFactory;
+import com.synopsys.integration.log.LogLevel;
+import com.synopsys.integration.log.PrintStreamIntLogger;
 
 class PluginManagerServiceServerTestIT extends JiraServerParameterizedTestIT {
 
-    @ParameterizedTest
-    @MethodSource("getParameters")
-    void createIssueTest(JiraHttpClient jiraHttpClient) throws IntegrationException {
+    @Test
+    void createIssueTest() throws IntegrationException {
+        JiraHttpClient jiraHttpClient = JiraServerServiceTestUtility.createJiraCredentialClient(new PrintStreamIntLogger(System.out, LogLevel.WARN));
         JiraServerServiceTestUtility.validateConfiguration();
 
         JiraServerServiceFactory serviceFactory = JiraServerServiceTestUtility.createServiceFactory(jiraHttpClient);
@@ -25,9 +26,9 @@ class PluginManagerServiceServerTestIT extends JiraServerParameterizedTestIT {
         System.out.println("App is installed " + appInstalled);
     }
 
-    @ParameterizedTest
-    @MethodSource("getParameters")
-    void retrievePluginTokenJiraServerCredentialClientTest(JiraHttpClient jiraHttpClient) throws IntegrationException {
+    @Test
+    void retrievePluginTokenJiraServerCredentialClientTest() throws IntegrationException {
+        JiraHttpClient jiraHttpClient = JiraServerServiceTestUtility.createJiraCredentialClient(new PrintStreamIntLogger(System.out, LogLevel.WARN));
         JiraServerServiceTestUtility.validateConfiguration();
 
         JiraServerServiceFactory serviceFactory = JiraServerServiceTestUtility.createServiceFactory(jiraHttpClient);


### PR DESCRIPTION
PluginManagerService adds "os_authType=basic" as a query parameter which is not valid for the other clients tested in PluginManagerServiceServerTestIT (JiraAccessTokenHttpClient, JiraOAuthHttpClient).

The error from Jira is `Basic Authentication Failure - provided SessionId cookie along mismatched basic auth`