### PR TITLE
IALERT-3736 - Update expected path for alert-issue-property-indexer

### DIFF
--- a/src/test/java/com/blackduck/integration/jira/common/cloud/service/JiraCloudAppServiceTestIT.java
+++ b/src/test/java/com/blackduck/integration/jira/common/cloud/service/JiraCloudAppServiceTestIT.java
@@ -23,7 +23,7 @@ import com.blackduck.integration.rest.exception.IntegrationRestException;
 
 class JiraCloudAppServiceTestIT extends JiraCloudParameterizedTestIT {
     private static final int WAIT_TIME = 10000;
-    private static final String APP_KEY = "com.blackduck.integration.alert";
+    private static final String APP_KEY = "com.synopsys.integration.alert";
     private static final String APP_CLOUD_URI = "https://blackducksoftware.github.io/alert-issue-property-indexer/JiraCloudApp/1.0.0/atlassian-connect.json";
 
     @AfterEach

--- a/src/test/java/com/blackduck/integration/jira/common/server/JiraServerAppServiceTestIT.java
+++ b/src/test/java/com/blackduck/integration/jira/common/server/JiraServerAppServiceTestIT.java
@@ -21,7 +21,7 @@ import com.blackduck.integration.rest.RestConstants;
 import com.blackduck.integration.rest.exception.IntegrationRestException;
 
 public class JiraServerAppServiceTestIT extends JiraServerParameterizedTestIT {
-    private static final String APP_KEY = "com.blackduck.integration.alert";
+    private static final String APP_KEY = "com.synopsys.integration.alert";
     private static final String APP_SERVER_URI = "https://blackducksoftware.github.io/alert-issue-property-indexer/JiraServerApp/1.0.0/atlassian-plugin.xml";
 
     // If these tests start breaking, verify the 'Barcharts for Jira' plugin is still free and available.


### PR DESCRIPTION
alert-issue-property-indexer has not yet released with it's rebranding. Because of that, the path still contains 'synopsys'. Change the tests, knowing we will need a follow up release.