### PR TITLE
IALERT-3926: Check auth type when making requests to plugin service

### DIFF
--- a/src/main/java/com/blackduck/integration/jira/common/rest/service/JiraApiClient.java
+++ b/src/main/java/com/blackduck/integration/jira/common/rest/service/JiraApiClient.java
@@ -136,6 +136,10 @@ public class JiraApiClient {
         return execute(jiraRequest).getHeaders();
     }
 
+    public JiraHttpClient getHttpClient() {
+        return httpClient;
+    }
+
     private <R extends JiraResponseModel> R execute(JiraRequest jiraRequest, Type type) throws IntegrationException {
         JiraResponse jiraResponse = httpClient.execute(jiraRequest);
         return parseResponse(jiraResponse, type);

--- a/src/main/java/com/blackduck/integration/jira/common/rest/service/PluginManagerService.java
+++ b/src/main/java/com/blackduck/integration/jira/common/rest/service/PluginManagerService.java
@@ -15,8 +15,10 @@ import com.blackduck.integration.jira.common.model.request.AppUploadRequestModel
 import com.blackduck.integration.jira.common.model.response.AvailableAppResponseModel;
 import com.blackduck.integration.jira.common.model.response.InstalledAppsResponseModel;
 import com.blackduck.integration.jira.common.model.response.PluginResponseModel;
+import com.blackduck.integration.jira.common.rest.JiraHttpClient;
 import com.blackduck.integration.jira.common.rest.model.JiraRequest;
 import com.blackduck.integration.jira.common.rest.model.JiraResponse;
+import com.blackduck.integration.jira.common.rest.token.JiraAccessTokenHttpClient;
 import com.blackduck.integration.rest.HttpMethod;
 import com.blackduck.integration.rest.HttpUrl;
 import com.blackduck.integration.rest.exception.IntegrationRestException;
@@ -45,16 +47,20 @@ public class PluginManagerService {
 
     private final Gson gson;
     private final JiraApiClient jiraApiClient;
+    private final JiraHttpClient jiraHttpClient;
 
     public PluginManagerService(Gson gson, JiraApiClient jiraApiClient) {
         this.gson = gson;
         this.jiraApiClient = jiraApiClient;
+        jiraHttpClient = jiraApiClient.getHttpClient();
     }
 
     public Optional<PluginResponseModel> getInstalledApp(String appKey) throws IntegrationException {
         HttpUrl apiUri = new HttpUrl(createBaseRequestUrl() + appKey + "-key");
         JiraRequest.Builder requestBuilder = new JiraRequest.Builder(apiUri);
-        requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
+        if (!(jiraHttpClient instanceof JiraAccessTokenHttpClient)) {
+            requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
+        }
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_PLUGIN);
 
@@ -72,7 +78,9 @@ public class PluginManagerService {
     public boolean isAppInstalled(String appKey) throws IntegrationException {
         HttpUrl apiUri = new HttpUrl(createBaseRequestUrl() + appKey + "-key");
         JiraRequest.Builder requestBuilder = new JiraRequest.Builder(apiUri);
-        requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
+        if (!(jiraHttpClient instanceof JiraAccessTokenHttpClient)) {
+            requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
+        }
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_PLUGIN);
 
@@ -91,7 +99,9 @@ public class PluginManagerService {
     public InstalledAppsResponseModel getInstalledApps() throws IntegrationException {
         HttpUrl httpUrl = new HttpUrl(createBaseRequestUrl());
         JiraRequest.Builder requestBuilder = new JiraRequest.Builder(httpUrl);
-        requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
+        if (!(jiraHttpClient instanceof JiraAccessTokenHttpClient)) {
+            requestBuilder.addQueryParameter(QUERY_KEY_OS_AUTH_TYPE, QUERY_VALUE_OS_AUTH_TYPE);
+        }
         requestBuilder.method(HttpMethod.GET);
         requestBuilder.addHeader(ACCEPT_HEADER, MEDIA_TYPE_INSTALLED);
 

--- a/src/test/java/com/blackduck/integration/jira/common/rest/service/PluginManagerServiceServerTestIT.java
+++ b/src/test/java/com/blackduck/integration/jira/common/rest/service/PluginManagerServiceServerTestIT.java
@@ -39,4 +39,20 @@ class PluginManagerServiceServerTestIT {
         String pluginToken = pluginManagerService.retrievePluginToken();
         assertNotNull(pluginToken);
     }
+
+    /**
+     * By default, it is assumed when checking plugins we are using basic auth. This test validates the Jira plugin endpoint works even with a Jira Bearer Auth.
+     * @throws IntegrationException
+     */
+    @Test
+    void isAppInstalledBearerTokenAuthTest() throws IntegrationException {
+        JiraHttpClient jiraHttpClient = JiraServerServiceTestUtility.createJiraBearerAuthClient(new PrintStreamIntLogger(System.out, LogLevel.WARN));
+        JiraServerServiceTestUtility.validateConfiguration();
+
+        JiraServerServiceFactory serviceFactory = JiraServerServiceTestUtility.createServiceFactory(jiraHttpClient);
+        PluginManagerService pluginManagerService = serviceFactory.createPluginManagerService();
+
+        boolean appInstalled = pluginManagerService.isAppInstalled("com.blackduck.integration.alert");
+        System.out.println("App is installed " + appInstalled);
+    }
 }


### PR DESCRIPTION
When the plugin service for Jira is called we set a request header for os_authType=basic. This was required at some point in Jira's lifecycle when we were making requests out to the plugin service. This functionality was discovered to be broken in Alert when we attempt to run with Bearer auth as there is no user/password expected if Basic is used.

The change is to maintain legacy functionality and continue setting the authType to basic. We will now conditionally determine whether or not to include this query parameter based on the type of authentication used.